### PR TITLE
NPT-560 Currently build_gqlgen and build_nexus-openapigen fails

### DIFF
--- a/compiler/pkg/crd-generator/template/graphql/graphqlResolver.go.tmpl
+++ b/compiler/pkg/crd-generator/template/graphql/graphqlResolver.go.tmpl
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
 
 	nexus_client "{{.BaseImportPath}}nexus-client"
 	"{{.BaseImportPath}}nexus-gql/graph/model"
@@ -27,18 +28,23 @@ func getParentName(parentLabels map[string]interface{}, key string) string {
 // Nexus K8sAPIEndpointConfig
 //////////////////////////////////////
 func getK8sAPIEndpointConfig() *rest.Config {
+    var (
+		config *rest.Config
+		err    error
+	)
 	filePath := os.Getenv("KUBECONFIG")
 	if filePath != "" {
-		config, err := clientcmd.BuildConfigFromFlags("", filePath)
+		config, err = clientcmd.BuildConfigFromFlags("", filePath)
 		if err != nil {
 			return nil
 		}
-		return config
+	} else {
+	    config, err = rest.InClusterConfig()
+	    if err != nil {
+		    return nil
+	    }
 	}
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil
-	}
+	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(200, 300)
 	return config
 }
 {{- range $key, $node := .Nodes }}


### PR DESCRIPTION
in build_gqlgen and build_openapigen GOBIN is hardcoded to use PKG_NAME/cmd in which PKG_NAME is default to /go/src.. for _in_container methods

removing the dependency for PKG_NAME and changing to use PWD instead of PKG_NAME and migrate to COMPILER_DIR_NAME