### PR TITLE
NPT-573 Give user inside build container ownership over the git dir

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -35,7 +35,7 @@ define run_in_container
   --network=host \
   --workdir ${PKG_NAME} \
   --user $(shell id -u):$(shell id -g) \
-  "${BUILDER_NAME}:${BUILDER_TAG}" /bin/bash -c "${1}"
+  "${BUILDER_NAME}:${BUILDER_TAG}" /bin/bash -c 'chown -R $(shell id -u) .; ${1}'
 endef
 else
 define run_in_container


### PR DESCRIPTION
A change was made to use the user id on the host machine as the userid inside the docker container when running compiler inside container. However the user id of the host and inside container are essentially two different id's. Git detects this and complains that the ownership associated with the git repo directory is ambiguous.

This commit adds a change to give ownership of the git repo directory to the user id mounted inside the container.