### PR TITLE
NPT-599 Increase resolver count for custom queries

### DIFF
--- a/compiler/example/datamodel/config/policy/policy.go
+++ b/compiler/example/datamodel/config/policy/policy.go
@@ -65,6 +65,7 @@ type ResourceGroupID struct {
 
 type ResourceGroupIDs []ResourceGroupID
 
+// nexus-graphql-query:gns.CloudEndpointGraphQLQuerySpec
 type VMpolicy struct {
 	nexus.Node
 }

--- a/compiler/example/output/_rendered_templates/nexus-gql/gqlgen.yml
+++ b/compiler/example/output/_rendered_templates/nexus-gql/gqlgen.yml
@@ -54,6 +54,12 @@ models:
         resolver: true
   gns_Gns:
     fields:
+      queryGns1:
+        resolver: true
+      queryGnsQM1:
+        resolver: true
+      queryGnsQM:
+        resolver: true
       GnsAccessControlPolicy:
         resolver: true
       FooChild:
@@ -61,4 +67,12 @@ models:
   policypkg_AccessControlPolicy:
     fields:
       PolicyConfigs:
+        resolver: true
+  policypkg_VMpolicy:
+    fields:
+      queryGns1:
+        resolver: true
+      queryGnsQM1:
+        resolver: true
+      queryGnsQM:
         resolver: true

--- a/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
@@ -189,6 +189,87 @@ func getGnsGnsqueryGnsQMResolver(obj *model.GnsGns,  StartTime *string,  EndTime
 	}
 	return resp.(*model.TimeSeriesData), nil
 }
+// Custom query
+func getPolicypkgVMpolicyqueryGns1Resolver(obj *model.PolicypkgVMpolicy,  StartTime *string,  EndTime *string,  Interval *string,  IsServiceDeployment *bool,  StartVal *int, ) (*model.NexusGraphqlResponse, error) {
+	parentLabels := make(map[string]string)
+	if obj != nil {
+		for k, v := range obj.ParentLabels {
+			val, ok := v.(string)
+			if ok {
+				parentLabels[k] = val
+			}
+		}
+	}
+	query := &graphql.GraphQLQuery{
+		Query: "queryGns1",
+		UserProvidedArgs: map[string]string{
+			"StartTime": pointerToString(StartTime),
+			"EndTime": pointerToString(EndTime),
+			"Interval": pointerToString(Interval),
+			"IsServiceDeployment": pointerToString(IsServiceDeployment),
+			"StartVal": pointerToString(StartVal),
+		},
+		Hierarchy: parentLabels,
+	}
+
+	resp, err := c.Request("nexus-query-responder:15000", nexus.GraphQLQueryApi, query)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*model.NexusGraphqlResponse), nil
+}
+// Custom query
+func getPolicypkgVMpolicyqueryGnsQM1Resolver(obj *model.PolicypkgVMpolicy, ) (*model.TimeSeriesData, error) {
+	parentLabels := make(map[string]string)
+	if obj != nil {
+		for k, v := range obj.ParentLabels {
+			val, ok := v.(string)
+			if ok {
+				parentLabels[k] = val
+			}
+		}
+	}
+	metricArgs := &qm.MetricArg{
+		QueryType: "/queryGnsQM1",
+		Hierarchy: parentLabels,
+		UserProvidedArgs: map[string]string{
+		},
+	}
+	resp, err := c.Request("query-manager:15002", nexus.GetMetricsApi, metricArgs)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*model.TimeSeriesData), nil
+}
+// Custom query
+func getPolicypkgVMpolicyqueryGnsQMResolver(obj *model.PolicypkgVMpolicy,  StartTime *string,  EndTime *string,  TimeInterval *string,  SomeUserArg1 *string,  SomeUserArg2 *int,  SomeUserArg3 *bool, ) (*model.TimeSeriesData, error) {
+	parentLabels := make(map[string]string)
+	if obj != nil {
+		for k, v := range obj.ParentLabels {
+			val, ok := v.(string)
+			if ok {
+				parentLabels[k] = val
+			}
+		}
+	}
+	metricArgs := &qm.MetricArg{
+		QueryType: "/queryGnsQM",
+		StartTime: *StartTime,
+		EndTime: *EndTime,
+		TimeInterval: *TimeInterval,
+		Hierarchy: parentLabels,
+		UserProvidedArgs: map[string]string{
+			"SomeUserArg1": pointerToString(SomeUserArg1),
+			"SomeUserArg2": pointerToString(SomeUserArg2),
+			"SomeUserArg3": pointerToString(SomeUserArg3),
+		},
+	}
+	resp, err := c.Request("query-manager:15003", nexus.GetMetricsApi, metricArgs)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*model.TimeSeriesData), nil
+}
 //////////////////////////////////////
 // CHILD RESOLVER (Non Singleton)
 // FieldName: Config Node: Root PKG: Root

--- a/compiler/example/output/_rendered_templates/nexus-gql/graph/schema.graphqls
+++ b/compiler/example/output/_rendered_templates/nexus-gql/graph/schema.graphqls
@@ -11,7 +11,6 @@ type root_Root {
 }
 
 type config_Config {
-    
     Id: ID
 	ParentLabels: Map
     QueryExample(
@@ -85,7 +84,6 @@ type gns_Gns {
         SomeUserArg3: Boolean
     ): TimeSeriesData
 
-    
     Domain: String
     UseSharedGateway: Boolean
     Description: String
@@ -145,10 +143,6 @@ type policypkg_ACPConfig {
     Id: ID
 	ParentLabels: Map
 
-    
-    
-    
-    
     DisplayName: String
     Gns: String
     Description: String
@@ -160,6 +154,22 @@ type policypkg_ACPConfig {
 type policypkg_VMpolicy {
     Id: ID
 	ParentLabels: Map
+    queryGns1(
+        StartTime: String
+        EndTime: String
+        Interval: String
+        IsServiceDeployment: Boolean
+        StartVal: Int
+    ): NexusGraphqlResponse
+    queryGnsQM1: TimeSeriesData
+    queryGnsQM(
+        StartTime: String
+        EndTime: String
+        TimeInterval: String
+        SomeUserArg1: String
+        SomeUserArg2: Int
+        SomeUserArg3: Boolean
+    ): TimeSeriesData
 
 }
 

--- a/compiler/example/output/generated/nexus-gql/gqlgen.yml
+++ b/compiler/example/output/generated/nexus-gql/gqlgen.yml
@@ -54,6 +54,12 @@ models:
         resolver: true
   gns_Gns:
     fields:
+      queryGns1:
+        resolver: true
+      queryGnsQM1:
+        resolver: true
+      queryGnsQM:
+        resolver: true
       GnsAccessControlPolicy:
         resolver: true
       FooChild:
@@ -61,4 +67,12 @@ models:
   policypkg_AccessControlPolicy:
     fields:
       PolicyConfigs:
+        resolver: true
+  policypkg_VMpolicy:
+    fields:
+      queryGns1:
+        resolver: true
+      queryGnsQM1:
+        resolver: true
+      queryGnsQM:
         resolver: true

--- a/compiler/example/output/generated/nexus-gql/graph/generated/generated.go
+++ b/compiler/example/output/generated/nexus-gql/graph/generated/generated.go
@@ -41,6 +41,7 @@ type ResolverRoot interface {
 	Config_Config() Config_ConfigResolver
 	Gns_Gns() Gns_GnsResolver
 	Policypkg_AccessControlPolicy() Policypkg_AccessControlPolicyResolver
+	Policypkg_VMpolicy() Policypkg_VMpolicyResolver
 	Root_Root() Root_RootResolver
 }
 
@@ -174,6 +175,9 @@ type ComplexityRoot struct {
 	Policypkg_VMpolicy struct {
 		Id           func(childComplexity int) int
 		ParentLabels func(childComplexity int) int
+		QueryGns1    func(childComplexity int, startTime *string, endTime *string, interval *string, isServiceDeployment *bool, startVal *int) int
+		QueryGnsQM   func(childComplexity int, startTime *string, endTime *string, timeInterval *string, someUserArg1 *string, someUserArg2 *int, someUserArg3 *bool) int
+		QueryGnsQM1  func(childComplexity int) int
 	}
 
 	Root_Root struct {
@@ -216,6 +220,11 @@ type Gns_GnsResolver interface {
 }
 type Policypkg_AccessControlPolicyResolver interface {
 	PolicyConfigs(ctx context.Context, obj *model.PolicypkgAccessControlPolicy, id *string) ([]*model.PolicypkgACPConfig, error)
+}
+type Policypkg_VMpolicyResolver interface {
+	QueryGns1(ctx context.Context, obj *model.PolicypkgVMpolicy, startTime *string, endTime *string, interval *string, isServiceDeployment *bool, startVal *int) (*model.NexusGraphqlResponse, error)
+	QueryGnsQM1(ctx context.Context, obj *model.PolicypkgVMpolicy) (*model.TimeSeriesData, error)
+	QueryGnsQM(ctx context.Context, obj *model.PolicypkgVMpolicy, startTime *string, endTime *string, timeInterval *string, someUserArg1 *string, someUserArg2 *int, someUserArg3 *bool) (*model.TimeSeriesData, error)
 }
 type Root_RootResolver interface {
 	Config(ctx context.Context, obj *model.RootRoot, id *string) (*model.ConfigConfig, error)
@@ -914,6 +923,37 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Policypkg_VMpolicy.ParentLabels(childComplexity), true
 
+	case "policypkg_VMpolicy.queryGns1":
+		if e.complexity.Policypkg_VMpolicy.QueryGns1 == nil {
+			break
+		}
+
+		args, err := ec.field_policypkg_VMpolicy_queryGns1_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Policypkg_VMpolicy.QueryGns1(childComplexity, args["StartTime"].(*string), args["EndTime"].(*string), args["Interval"].(*string), args["IsServiceDeployment"].(*bool), args["StartVal"].(*int)), true
+
+	case "policypkg_VMpolicy.queryGnsQM":
+		if e.complexity.Policypkg_VMpolicy.QueryGnsQM == nil {
+			break
+		}
+
+		args, err := ec.field_policypkg_VMpolicy_queryGnsQM_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Policypkg_VMpolicy.QueryGnsQM(childComplexity, args["StartTime"].(*string), args["EndTime"].(*string), args["TimeInterval"].(*string), args["SomeUserArg1"].(*string), args["SomeUserArg2"].(*int), args["SomeUserArg3"].(*bool)), true
+
+	case "policypkg_VMpolicy.queryGnsQM1":
+		if e.complexity.Policypkg_VMpolicy.QueryGnsQM1 == nil {
+			break
+		}
+
+		return e.complexity.Policypkg_VMpolicy.QueryGnsQM1(childComplexity), true
+
 	case "root_Root.Config":
 		if e.complexity.Root_Root.Config == nil {
 			break
@@ -1047,7 +1087,6 @@ type root_Root {
 }
 
 type config_Config {
-    
     Id: ID
 	ParentLabels: Map
     QueryExample(
@@ -1121,7 +1160,6 @@ type gns_Gns {
         SomeUserArg3: Boolean
     ): TimeSeriesData
 
-    
     Domain: String
     UseSharedGateway: Boolean
     Description: String
@@ -1181,10 +1219,6 @@ type policypkg_ACPConfig {
     Id: ID
 	ParentLabels: Map
 
-    
-    
-    
-    
     DisplayName: String
     Gns: String
     Description: String
@@ -1196,6 +1230,22 @@ type policypkg_ACPConfig {
 type policypkg_VMpolicy {
     Id: ID
 	ParentLabels: Map
+    queryGns1(
+        StartTime: String
+        EndTime: String
+        Interval: String
+        IsServiceDeployment: Boolean
+        StartVal: Int
+    ): NexusGraphqlResponse
+    queryGnsQM1: TimeSeriesData
+    queryGnsQM(
+        StartTime: String
+        EndTime: String
+        TimeInterval: String
+        SomeUserArg1: String
+        SomeUserArg2: Int
+        SomeUserArg3: Boolean
+    ): TimeSeriesData
 
 }
 
@@ -1546,6 +1596,117 @@ func (ec *executionContext) field_policypkg_AccessControlPolicy_PolicyConfigs_ar
 		}
 	}
 	args["Id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_policypkg_VMpolicy_queryGns1_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["StartTime"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("StartTime"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["StartTime"] = arg0
+	var arg1 *string
+	if tmp, ok := rawArgs["EndTime"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("EndTime"))
+		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["EndTime"] = arg1
+	var arg2 *string
+	if tmp, ok := rawArgs["Interval"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("Interval"))
+		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["Interval"] = arg2
+	var arg3 *bool
+	if tmp, ok := rawArgs["IsServiceDeployment"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("IsServiceDeployment"))
+		arg3, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["IsServiceDeployment"] = arg3
+	var arg4 *int
+	if tmp, ok := rawArgs["StartVal"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("StartVal"))
+		arg4, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["StartVal"] = arg4
+	return args, nil
+}
+
+func (ec *executionContext) field_policypkg_VMpolicy_queryGnsQM_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["StartTime"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("StartTime"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["StartTime"] = arg0
+	var arg1 *string
+	if tmp, ok := rawArgs["EndTime"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("EndTime"))
+		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["EndTime"] = arg1
+	var arg2 *string
+	if tmp, ok := rawArgs["TimeInterval"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("TimeInterval"))
+		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["TimeInterval"] = arg2
+	var arg3 *string
+	if tmp, ok := rawArgs["SomeUserArg1"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("SomeUserArg1"))
+		arg3, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["SomeUserArg1"] = arg3
+	var arg4 *int
+	if tmp, ok := rawArgs["SomeUserArg2"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("SomeUserArg2"))
+		arg4, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["SomeUserArg2"] = arg4
+	var arg5 *bool
+	if tmp, ok := rawArgs["SomeUserArg3"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("SomeUserArg3"))
+		arg5, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["SomeUserArg3"] = arg5
 	return args, nil
 }
 
@@ -4762,6 +4923,12 @@ func (ec *executionContext) fieldContext_config_Config_VMPPolicies(ctx context.C
 				return ec.fieldContext_policypkg_VMpolicy_Id(ctx, field)
 			case "ParentLabels":
 				return ec.fieldContext_policypkg_VMpolicy_ParentLabels(ctx, field)
+			case "queryGns1":
+				return ec.fieldContext_policypkg_VMpolicy_queryGns1(ctx, field)
+			case "queryGnsQM1":
+				return ec.fieldContext_policypkg_VMpolicy_queryGnsQM1(ctx, field)
+			case "queryGnsQM":
+				return ec.fieldContext_policypkg_VMpolicy_queryGnsQM(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type policypkg_VMpolicy", field.Name)
 		},
@@ -7467,6 +7634,187 @@ func (ec *executionContext) fieldContext_policypkg_VMpolicy_ParentLabels(ctx con
 	return fc, nil
 }
 
+func (ec *executionContext) _policypkg_VMpolicy_queryGns1(ctx context.Context, field graphql.CollectedField, obj *model.PolicypkgVMpolicy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_policypkg_VMpolicy_queryGns1(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Policypkg_VMpolicy().QueryGns1(rctx, obj, fc.Args["StartTime"].(*string), fc.Args["EndTime"].(*string), fc.Args["Interval"].(*string), fc.Args["IsServiceDeployment"].(*bool), fc.Args["StartVal"].(*int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.NexusGraphqlResponse)
+	fc.Result = res
+	return ec.marshalONexusGraphqlResponse2ᚖnexustempmoduleᚋnexusᚑgqlᚋgraphᚋmodelᚐNexusGraphqlResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_policypkg_VMpolicy_queryGns1(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "policypkg_VMpolicy",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "Code":
+				return ec.fieldContext_NexusGraphqlResponse_Code(ctx, field)
+			case "Message":
+				return ec.fieldContext_NexusGraphqlResponse_Message(ctx, field)
+			case "Data":
+				return ec.fieldContext_NexusGraphqlResponse_Data(ctx, field)
+			case "Last":
+				return ec.fieldContext_NexusGraphqlResponse_Last(ctx, field)
+			case "TotalRecords":
+				return ec.fieldContext_NexusGraphqlResponse_TotalRecords(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NexusGraphqlResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_policypkg_VMpolicy_queryGns1_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _policypkg_VMpolicy_queryGnsQM1(ctx context.Context, field graphql.CollectedField, obj *model.PolicypkgVMpolicy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_policypkg_VMpolicy_queryGnsQM1(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Policypkg_VMpolicy().QueryGnsQM1(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.TimeSeriesData)
+	fc.Result = res
+	return ec.marshalOTimeSeriesData2ᚖnexustempmoduleᚋnexusᚑgqlᚋgraphᚋmodelᚐTimeSeriesData(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_policypkg_VMpolicy_queryGnsQM1(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "policypkg_VMpolicy",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "Code":
+				return ec.fieldContext_TimeSeriesData_Code(ctx, field)
+			case "Message":
+				return ec.fieldContext_TimeSeriesData_Message(ctx, field)
+			case "Data":
+				return ec.fieldContext_TimeSeriesData_Data(ctx, field)
+			case "Last":
+				return ec.fieldContext_TimeSeriesData_Last(ctx, field)
+			case "TotalRecords":
+				return ec.fieldContext_TimeSeriesData_TotalRecords(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TimeSeriesData", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _policypkg_VMpolicy_queryGnsQM(ctx context.Context, field graphql.CollectedField, obj *model.PolicypkgVMpolicy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_policypkg_VMpolicy_queryGnsQM(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Policypkg_VMpolicy().QueryGnsQM(rctx, obj, fc.Args["StartTime"].(*string), fc.Args["EndTime"].(*string), fc.Args["TimeInterval"].(*string), fc.Args["SomeUserArg1"].(*string), fc.Args["SomeUserArg2"].(*int), fc.Args["SomeUserArg3"].(*bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.TimeSeriesData)
+	fc.Result = res
+	return ec.marshalOTimeSeriesData2ᚖnexustempmoduleᚋnexusᚑgqlᚋgraphᚋmodelᚐTimeSeriesData(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_policypkg_VMpolicy_queryGnsQM(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "policypkg_VMpolicy",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "Code":
+				return ec.fieldContext_TimeSeriesData_Code(ctx, field)
+			case "Message":
+				return ec.fieldContext_TimeSeriesData_Message(ctx, field)
+			case "Data":
+				return ec.fieldContext_TimeSeriesData_Data(ctx, field)
+			case "Last":
+				return ec.fieldContext_TimeSeriesData_Last(ctx, field)
+			case "TotalRecords":
+				return ec.fieldContext_TimeSeriesData_TotalRecords(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TimeSeriesData", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_policypkg_VMpolicy_queryGnsQM_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _root_Root_Id(ctx context.Context, field graphql.CollectedField, obj *model.RootRoot) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_root_Root_Id(ctx, field)
 	if err != nil {
@@ -9074,6 +9422,57 @@ func (ec *executionContext) _policypkg_VMpolicy(ctx context.Context, sel ast.Sel
 
 			out.Values[i] = ec._policypkg_VMpolicy_ParentLabels(ctx, field, obj)
 
+		case "queryGns1":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._policypkg_VMpolicy_queryGns1(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "queryGnsQM1":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._policypkg_VMpolicy_queryGnsQM1(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "queryGnsQM":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._policypkg_VMpolicy_queryGnsQM(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/compiler/example/output/generated/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/generated/nexus-gql/graph/graphqlResolver.go
@@ -200,6 +200,89 @@ func getGnsGnsqueryGnsQMResolver(obj *model.GnsGns, StartTime *string, EndTime *
 	return resp.(*model.TimeSeriesData), nil
 }
 
+// Custom query
+func getPolicypkgVMpolicyqueryGns1Resolver(obj *model.PolicypkgVMpolicy, StartTime *string, EndTime *string, Interval *string, IsServiceDeployment *bool, StartVal *int) (*model.NexusGraphqlResponse, error) {
+	parentLabels := make(map[string]string)
+	if obj != nil {
+		for k, v := range obj.ParentLabels {
+			val, ok := v.(string)
+			if ok {
+				parentLabels[k] = val
+			}
+		}
+	}
+	query := &graphql.GraphQLQuery{
+		Query: "queryGns1",
+		UserProvidedArgs: map[string]string{
+			"StartTime":           pointerToString(StartTime),
+			"EndTime":             pointerToString(EndTime),
+			"Interval":            pointerToString(Interval),
+			"IsServiceDeployment": pointerToString(IsServiceDeployment),
+			"StartVal":            pointerToString(StartVal),
+		},
+		Hierarchy: parentLabels,
+	}
+
+	resp, err := c.Request("nexus-query-responder:15000", nexus.GraphQLQueryApi, query)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*model.NexusGraphqlResponse), nil
+}
+
+// Custom query
+func getPolicypkgVMpolicyqueryGnsQM1Resolver(obj *model.PolicypkgVMpolicy) (*model.TimeSeriesData, error) {
+	parentLabels := make(map[string]string)
+	if obj != nil {
+		for k, v := range obj.ParentLabels {
+			val, ok := v.(string)
+			if ok {
+				parentLabels[k] = val
+			}
+		}
+	}
+	metricArgs := &qm.MetricArg{
+		QueryType:        "/queryGnsQM1",
+		Hierarchy:        parentLabels,
+		UserProvidedArgs: map[string]string{},
+	}
+	resp, err := c.Request("query-manager:15002", nexus.GetMetricsApi, metricArgs)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*model.TimeSeriesData), nil
+}
+
+// Custom query
+func getPolicypkgVMpolicyqueryGnsQMResolver(obj *model.PolicypkgVMpolicy, StartTime *string, EndTime *string, TimeInterval *string, SomeUserArg1 *string, SomeUserArg2 *int, SomeUserArg3 *bool) (*model.TimeSeriesData, error) {
+	parentLabels := make(map[string]string)
+	if obj != nil {
+		for k, v := range obj.ParentLabels {
+			val, ok := v.(string)
+			if ok {
+				parentLabels[k] = val
+			}
+		}
+	}
+	metricArgs := &qm.MetricArg{
+		QueryType:    "/queryGnsQM",
+		StartTime:    *StartTime,
+		EndTime:      *EndTime,
+		TimeInterval: *TimeInterval,
+		Hierarchy:    parentLabels,
+		UserProvidedArgs: map[string]string{
+			"SomeUserArg1": pointerToString(SomeUserArg1),
+			"SomeUserArg2": pointerToString(SomeUserArg2),
+			"SomeUserArg3": pointerToString(SomeUserArg3),
+		},
+	}
+	resp, err := c.Request("query-manager:15003", nexus.GetMetricsApi, metricArgs)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*model.TimeSeriesData), nil
+}
+
 //////////////////////////////////////
 // CHILD RESOLVER (Non Singleton)
 // FieldName: Config Node: Root PKG: Root

--- a/compiler/example/output/generated/nexus-gql/graph/model/models_gen.go
+++ b/compiler/example/output/generated/nexus-gql/graph/model/models_gen.go
@@ -124,6 +124,9 @@ type PolicypkgAccessControlPolicy struct {
 type PolicypkgVMpolicy struct {
 	Id           *string                `json:"Id"`
 	ParentLabels map[string]interface{} `json:"ParentLabels"`
+	queryGns1    *NexusGraphqlResponse  `json:"queryGns1"`
+	queryGnsQM1  *TimeSeriesData        `json:"queryGnsQM1"`
+	queryGnsQM   *TimeSeriesData        `json:"queryGnsQM"`
 }
 
 type RootRoot struct {

--- a/compiler/example/output/generated/nexus-gql/graph/schema.graphqls
+++ b/compiler/example/output/generated/nexus-gql/graph/schema.graphqls
@@ -11,7 +11,6 @@ type root_Root {
 }
 
 type config_Config {
-    
     Id: ID
 	ParentLabels: Map
     QueryExample(
@@ -85,7 +84,6 @@ type gns_Gns {
         SomeUserArg3: Boolean
     ): TimeSeriesData
 
-    
     Domain: String
     UseSharedGateway: Boolean
     Description: String
@@ -145,10 +143,6 @@ type policypkg_ACPConfig {
     Id: ID
 	ParentLabels: Map
 
-    
-    
-    
-    
     DisplayName: String
     Gns: String
     Description: String
@@ -160,6 +154,22 @@ type policypkg_ACPConfig {
 type policypkg_VMpolicy {
     Id: ID
 	ParentLabels: Map
+    queryGns1(
+        StartTime: String
+        EndTime: String
+        Interval: String
+        IsServiceDeployment: Boolean
+        StartVal: Int
+    ): NexusGraphqlResponse
+    queryGnsQM1: TimeSeriesData
+    queryGnsQM(
+        StartTime: String
+        EndTime: String
+        TimeInterval: String
+        SomeUserArg1: String
+        SomeUserArg2: Int
+        SomeUserArg3: Boolean
+    ): TimeSeriesData
 
 }
 

--- a/compiler/example/output/generated/nexus-gql/graph/schema.resolvers.go
+++ b/compiler/example/output/generated/nexus-gql/graph/schema.resolvers.go
@@ -85,6 +85,21 @@ func (r *policypkg_AccessControlPolicyResolver) PolicyConfigs(ctx context.Contex
 	return getPolicypkgAccessControlPolicyPolicyConfigsResolver(obj, id)
 }
 
+// QueryGns1 is the resolver for the queryGns1 field.
+func (r *policypkg_VMpolicyResolver) QueryGns1(ctx context.Context, obj *model.PolicypkgVMpolicy, startTime *string, endTime *string, interval *string, isServiceDeployment *bool, startVal *int) (*model.NexusGraphqlResponse, error) {
+	return getPolicypkgVMpolicyqueryGns1Resolver(obj, startTime, endTime, interval, isServiceDeployment, startVal)
+}
+
+// QueryGnsQM1 is the resolver for the queryGnsQM1 field.
+func (r *policypkg_VMpolicyResolver) QueryGnsQM1(ctx context.Context, obj *model.PolicypkgVMpolicy) (*model.TimeSeriesData, error) {
+	return getPolicypkgVMpolicyqueryGnsQM1Resolver(obj)
+}
+
+// QueryGnsQM is the resolver for the queryGnsQM field.
+func (r *policypkg_VMpolicyResolver) QueryGnsQM(ctx context.Context, obj *model.PolicypkgVMpolicy, startTime *string, endTime *string, timeInterval *string, someUserArg1 *string, someUserArg2 *int, someUserArg3 *bool) (*model.TimeSeriesData, error) {
+	return getPolicypkgVMpolicyqueryGnsQMResolver(obj, startTime, endTime, timeInterval, someUserArg1, someUserArg2, someUserArg3)
+}
+
 // Config is the resolver for the Config field.
 func (r *root_RootResolver) Config(ctx context.Context, obj *model.RootRoot, id *string) (*model.ConfigConfig, error) {
 	return getRootRootConfigResolver(obj, id)
@@ -104,6 +119,11 @@ func (r *Resolver) Policypkg_AccessControlPolicy() generated.Policypkg_AccessCon
 	return &policypkg_AccessControlPolicyResolver{r}
 }
 
+// Policypkg_VMpolicy returns generated.Policypkg_VMpolicyResolver implementation.
+func (r *Resolver) Policypkg_VMpolicy() generated.Policypkg_VMpolicyResolver {
+	return &policypkg_VMpolicyResolver{r}
+}
+
 // Root_Root returns generated.Root_RootResolver implementation.
 func (r *Resolver) Root_Root() generated.Root_RootResolver { return &root_RootResolver{r} }
 
@@ -111,4 +131,5 @@ type queryResolver struct{ *Resolver }
 type config_ConfigResolver struct{ *Resolver }
 type gns_GnsResolver struct{ *Resolver }
 type policypkg_AccessControlPolicyResolver struct{ *Resolver }
+type policypkg_VMpolicyResolver struct{ *Resolver }
 type root_RootResolver struct{ *Resolver }

--- a/compiler/pkg/generator/resolver_generator.go
+++ b/compiler/pkg/generator/resolver_generator.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"unicode"
 
 	log "github.com/sirupsen/logrus"
 
@@ -398,13 +397,11 @@ func processNexusFields(pkg parser.Package, aliasNameMap map[string]string, node
 			fieldProp.SchemaFieldName = CustomQuerySchema
 			for _, customQuery := range nodeProp.CustomQueries {
 				fieldProp.SchemaFieldName += CustomQueryToGraphqlSchema(customQuery)
-				if unicode.IsUpper(rune(customQuery.Name[0])) {
-					var customQueryFieldProp FieldProperty
-					customQueryFieldProp.IsResolver = true
-					customQueryFieldProp.FieldName = customQuery.Name
-					nodeProp.GraphqlSchemaFields = append(nodeProp.GraphqlSchemaFields, customQueryFieldProp)
-				}
-
+				var customQueryFieldProp FieldProperty
+				customQueryFieldProp.IsResolver = true
+				customQueryFieldProp.FieldName = customQuery.Name
+				nodeProp.GraphqlSchemaFields = append(nodeProp.GraphqlSchemaFields, customQueryFieldProp)
+				nodeProp.ResolverCount += 1
 			}
 		}
 

--- a/compiler/pkg/generator/template/graphql/schema.graphqls.tmpl
+++ b/compiler/pkg/generator/template/graphql/schema.graphqls.tmpl
@@ -13,7 +13,9 @@ type Query {
 {{ $length := len $node.GraphqlSchemaFields }}{{- if eq $length 0 }}{{- else }}
 type {{ $node.SchemaName }} {
     {{- range $key, $field := $node.GraphqlSchemaFields }}
+    {{- if $field.SchemaFieldName }}
     {{ $field.SchemaFieldName -}}
+    {{- end}}
     {{- end }}
 }
 {{- end }}{{- end }}{{- end }}


### PR DESCRIPTION
In graphql schema template we depend on resolver count being greater than 0, if it's zero schema for given node is not generated. For now resolver count was increased only if there was a child/link node defined, so when there weren't any child or node count was 0, so there schema was not resolved properly for custom queries.

Now increase resolver count also for custom queries so template is resolved properly when there is no child or link, but only custom queries in given node.