### PR TITLE
NPT-619 Add single nexus version for compiler and CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build Compiler image
 on:
   pull_request:
     branches: [ main ]
-  create:
-    tags:
-      - v*
 jobs:
   build:
     name: Build
@@ -31,7 +28,7 @@ jobs:
             if [[ $GITHUB_REF_TYPE == "tag" ]]; then
               IMAGE_TAG=$GITHUB_REF_NAME
             else
-              IMAGE_TAG=$(find compiler/ -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | awk '{print $1}')
+              IMAGE_TAG=$(git rev-parse --verify HEAD)
             fi
             echo "Building compiler image with tag: $IMAGE_TAG"
             pushd compiler

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release compiler image and CLI Binaries
+on:
+  create:
+    tags:
+      - v*
+jobs:
+  release-compiler-image:
+    name: Release compiler image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout github repository
+        uses: actions/checkout@v2
+      - name: Setup Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@1.0.11
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v0'
+      - name: Build Compiler image
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GCPServiceAccountKey }}
+          GCR_REPOSITORY: gcr.io/nsx-sm
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+        run: |
+            set -x
+            echo $GOOGLE_SERVICE_ACCOUNT_KEY | docker login -u _json_key --password-stdin $GCR_REPOSITORY
+            git config --global url."https://github.com/".insteadOf "git@github.com:"
+            IMAGE_TAG=$GITHUB_REF_NAME
+            echo "Building compiler image with tag: $IMAGE_TAG"
+            pushd compiler
+              make docker.builder
+              make build_in_container
+              make docker TAG=$IMAGE_TAG
+              make publish TAG=$IMAGE_TAG
+            popd
+            pushd cli
+              make build BUILD_VERSION=$GITHUB_REF_NAME
+            popd
+      - name: Upload CLI Binaries - DarwinAMD64
+        id: upload-cli-binaries-darwin-amd64
+        uses: svenstaro/upload-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+        with:
+          repo_token: ${{ secrets.GITHUBTOKEN }}
+          file: ./cli/artifacts/nexus/nexus-darwin_amd64
+          asset_name: nexus-darwin_amd64
+          tag: ${{ github.ref }}
+      - name: Upload CLI Binaries - LinuxAMD64
+        id: upload-cli-binaries-linux-amd64
+        uses: svenstaro/upload-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+        with:
+          repo_token: ${{ secrets.GITHUBTOKEN }}
+          file: ./cli/artifacts/nexus/nexus-linux_amd64
+          asset_name: nexus-linux_amd64
+          tag: ${{ github.ref }}
+      - name: Upload CLI Binaries - LinuxARM64
+        id: upload-cli-binaries-linux-arm64
+        uses: svenstaro/upload-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+        with:
+          repo_token: ${{ secrets.GITHUBTOKEN }}
+          file: ./cli/artifacts/nexus/nexus-linux_arm64
+          asset_name: nexus-linux_arm64
+          tag: ${{ github.ref }}
+      - name: Upload CLI Binaries - DarwinARM64
+        id: upload-cli-binaries-darwin-arm64
+        uses: svenstaro/upload-release-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+        with:
+          repo_token: ${{ secrets.GITHUBTOKEN }}
+          file: ./cli/artifacts/nexus/nexus-darwin_arm64
+          asset_name: nexus-darwin_arm64
+          tag: ${{ github.ref }}
+

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -8,7 +8,7 @@ GIT_BRANCH := $(shell git show-ref | grep "$(GIT_REVISION)" | \
 	   sed 's|refs/remotes/origin/||' | \
 	   sed 's|refs/heads/||' | sort | head -n 1)
 
-BUILD_VERSION ?= $$(cat BUILD_VERSION)
+BUILD_VERSION ?= $(GIT_REVISION)
 
 PKG = gitlab.eng.vmware.com/nsx-allspark_users/nexus-sdk/$(PACKAGE_NAME)
 COMMON_PACKAGE = $(PKG)/pkg/common
@@ -37,6 +37,10 @@ build:
 	mv nexus $(ARTIFACTS_PATH)/nexus-darwin_amd64
 	GOOS=linux GOARCH=amd64 go build --ldflags "$(GO_LDFLAGS)" ./cmd/plugin/nexus
 	mv nexus $(ARTIFACTS_PATH)/nexus-linux_amd64
+	GOOS=darwin GOARCH=arm64 go build --ldflags "$(GO_LDFLAGS)" ./cmd/plugin/nexus
+	mv nexus $(ARTIFACTS_PATH)/nexus-darwin_arm64
+	GOOS=linux GOARCH=arm64 go build --ldflags "$(GO_LDFLAGS)" ./cmd/plugin/nexus
+	mv nexus $(ARTIFACTS_PATH)/nexus-linux_arm64
 
 .PHONY: install
 install:

--- a/cli/pkg/common/global.go
+++ b/cli/pkg/common/global.go
@@ -17,7 +17,7 @@ import (
 )
 
 // VERSION ...Version set at compile time.
-var VERSION string
+var VERSION string = "unknown"
 
 // OS ...OS set at compile time.
 var OS string

--- a/cli/pkg/common/repos.yaml
+++ b/cli/pkg/common/repos.yaml
@@ -5,6 +5,6 @@
 - name: nexusDatamodelTemplates
   repoName: git@gitlab.eng.vmware.com:nsx-allspark_users/nexus-sdk/datamodel-templates.git
 - name: nexusCompiler
-  repoName: git@gitlab.eng.vmware.com:nsx-allspark_users/nexus-sdk/compiler.git
+  repoName: git@github.com:vmware-tanzu/graph-framework-for-microservices/compiler
 - name: nexusValidation
   repoName: git@gitlab.eng.vmware.com:nsx-allspark_users/nexus-sdk/nexus-validation.git

--- a/cli/pkg/common/values.yaml
+++ b/cli/pkg/common/values.yaml
@@ -1,7 +1,3 @@
-nexusCli:
-  version: v0.0.124
-nexusCompiler:
-  version: v0.0.55
 nexusAppTemplates:
   version: v0.0.10
 nexusDatamodelTemplates:

--- a/cli/pkg/servicemesh/datamodel/build.go
+++ b/cli/pkg/servicemesh/datamodel/build.go
@@ -39,7 +39,7 @@ func Build(cmd *cobra.Command, args []string) error {
 		prereq.PreReqListOnDemand(prerequisites)
 		return nil
 	}
-	compilerVersion, err := utils.GetTagVersion("NexusCompiler", "NEXUS_DATAMODEL_COMPILER_VERSION")
+	compilerVersion, err := utils.GetTagVersion("Nexus", "NEXUS_DATAMODEL_COMPILER_VERSION")
 	if err != nil {
 		return utils.GetCustomError(utils.DATAMODEL_BUILD_FAILED, fmt.Errorf("could not get compiler Version information due to %s", err)).Print().ExitIfFatalOrReturn()
 	}

--- a/cli/pkg/servicemesh/version/update.go
+++ b/cli/pkg/servicemesh/version/update.go
@@ -1,9 +1,11 @@
 package version
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/cli/pkg/common"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/cli/pkg/log"
 )
 
@@ -23,18 +25,24 @@ func IsNexusCliUpdateAvailable() (bool, string) {
 		return false, ""
 	}
 
-	if latestNexusVersionStripped != currentValues.NexusCli.Version {
+	if latestNexusVersionStripped != common.VERSION {
 		log.Debugf("Latest available Nexus CLI version: %s\n", latestNexusVersion)
-		log.Debugf("Current Nexus CLI version: %s\n", currentValues.NexusCli.Version)
+		log.Debugf("Current Nexus CLI version: %s\n", common.VERSION)
 	}
-
 	latestNexusVersionSemver, err := semver.NewVersion(latestNexusVersionStripped)
 	if err != nil {
 		log.Debugf("Latest Nexus version is incorrectly formatted: %v\n", err)
 		return false, ""
 	}
+	regexM := regexp.MustCompile(`(v?\d+.\d+.\d+$)`)
+	versionString := regexM.FindStringSubmatch(common.VERSION)
+	if len(versionString) != 2 {
+		log.Debugf("Current Nexus Version is not official version: %s\n, Please use --version to force upgrade", common.VERSION)
+		return false, ""
 
-	currentNexusVersionSemver, err := semver.NewVersion(format(currentValues.NexusCli.Version))
+	}
+
+	currentNexusVersionSemver, err := semver.NewVersion(format(common.VERSION))
 	if err != nil {
 		log.Debugf("Current Nexus version is incorrectly formatted: %v\n", err)
 		return false, ""

--- a/cli/pkg/servicemesh/version/version.go
+++ b/cli/pkg/servicemesh/version/version.go
@@ -12,8 +12,6 @@ import (
 )
 
 type NexusValues struct {
-	NexusCli                versionFields `yaml:"nexusCli"`
-	NexusCompiler           versionFields `yaml:"nexusCompiler"`
 	NexusAppTemplates       versionFields `yaml:"nexusAppTemplates"`
 	NexusDatamodelTemplates versionFields `yaml:"nexusDatamodelTemplates"`
 	NexusRuntime            versionFields `yaml:"nexusRuntime"`
@@ -30,8 +28,7 @@ func Version(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("NexusCli: %s\n", values.NexusCli.Version)
-	fmt.Printf("NexusCompiler: %s\n", values.NexusCompiler.Version)
+	fmt.Printf("Nexus: %s\n", common.VERSION)
 	fmt.Printf("NexusAppTemplates: %s\n", values.NexusAppTemplates.Version)
 	fmt.Printf("NexusDatamodelTemplates: %s\n", values.NexusDatamodelTemplates.Version)
 	fmt.Printf("NexusRuntimeManifets: %s\n", values.NexusRuntime.Version)
@@ -55,7 +52,7 @@ func GetNexusValues(values *NexusValues) error {
 }
 
 func GetLatestNexusVersion() (string, error) {
-	const cliRepo = "git@gitlab.eng.vmware.com:nsx-allspark_users/nexus-sdk/cli"
+	const cliRepo = "git@github.com:vmware-tanzu/graph-framework-for-microservices.git"
 	output, err := exec.Command("git", "ls-remote", "-t", "--sort", "-v:refname", cliRepo).Output()
 	if err != nil {
 		errMsg := fmt.Sprintf("Nexus CLI Upgrade check: failed to fetch remote tags from Nexus CLI repo. Please ensure you are able to clone this repo: `git clone %s`", cliRepo)

--- a/cli/pkg/utils/checks.go
+++ b/cli/pkg/utils/checks.go
@@ -37,6 +37,9 @@ func GetTagVersion(versionKey, EnvKey string) (string, error) {
 	var values version.NexusValues
 	resultVersion := os.Getenv(EnvKey)
 	if resultVersion == "" {
+		if versionKey == "Nexus" {
+			return common.VERSION, nil
+		}
 		yamlFile, err := common.TemplateFs.ReadFile("values.yaml")
 		if err != nil {
 			return "", fmt.Errorf("error while reading version yamlFile %v", err)


### PR DESCRIPTION
currently, CLI and Compiler version has two different entities 

* removing NexusCLI and NexusCompiler versions from values.yml
* using BuildVERSION from go ldflags to store version
* create CLI binaries for Darwin,Linux(AMD64/ARM64) and store it on each release binaries