### PR TITLE
51 Use Github form schema in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,49 +1,121 @@
----
-name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: bug
-assignees: ''
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+assignees:
+- xmen4xp
+  body:
+- type: markdown
+  attributes:
+  value: |
+  Thanks for taking the time to fill out this bug report!
+- type: input
+  id: contact
+  attributes:
+    label: Contact Details
+    description: How can we get in touch with you if we need more info?
+    placeholder: ex. email@example.com
+    validations:
+    required: false
+- type: textarea
+    id: version
+    attributes:
+    label: What version are you running?
+    description: Output of: nexus version
+    placeholder: Output of: nexus version
+    value: "Output of: nexus version"
+    validations:
+    required: true
+- type: textarea
+  id: what-happened
+  attributes:
+    label: What happened?
+    description: Describe the bug
+    placeholder: Tell us what you see!
+    value: "A bug happened!"
+    validations:
+    required: true
+- type: textarea
+  id: what-was-expected-behavior
+  attributes:
+    label: Describe the expected behavior
+    description: What was the expected behavior?
+    placeholder: What was the expected behavior?
+    value: "Not Applicable"
+    validations:
+    required: false
+- type: dropdown
+  id: priority
+  attributes:
+  label: How critical is this bug to you?
+  multiple: false
+  options:
+  - Blocker - solution is unusable without this feature
+  - Critical - solution is severely limited in value without this feature
+  - Major - important feature to be incorporated as there are no  known alternatives in the solution
+  - Minor - nice to have feature that adds value to the solution
+- type: textarea
+  id: how-can-we-recreate-the-bug
+  attributes:
+    label: How can we recreate the bug?
+    description: Share with us, the steps to hit the bug
+    placeholder: Share with us, the steps to hit the bug
+    value: "Not Applicable"
+    validations:
+    required: false
+- type: markdown
+    attributes:
+    value: |
+    Providing additional details would speed up resolution of the issue by many light years !
+    For generic debug info, attach output of:
+    '''
+    nexus debug
+    '''
+  
+    For compilation bugs, output of:
+    '''
+    nexus datamodel build --debug
+    '''
 
----
-
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-Steps to reproduce the behavior.
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Version:**
- - Output of the command:    nexus version
-
-**Debug:**
-
-1.  Output of the command:
-      - nexus debug
-     
-3.  For build failures:                  
-      - nexus datamodel build --debug
-
-4.  For installation failures:
-      - nexus prereq verify
-      -  kubectl get pods -A -o yaml
-
-
-**System:**
- - OS: [e.g. iOS]
-
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Additional context**
-Add any other context about the problem here.
-
-**Requester**
-Select from the list of well known requesters or select "Community"
-- [x] Community
-- [ ] Project ServiceMesh
-- [ ] Project Mazinger
-- [ ] Project Watch
+    For installation bugs, output of:
+    '''
+    nexus prereq verify
+    kubectl get pods -A -o yaml
+    '''
+- type: textarea
+  id: debug
+  attributes:
+  label: Any debug data that you are able to share?
+  description: Any debug data that you are able to share?
+  placeholder: Any debug data that you are able to share?
+  value: "Not Applicable"
+  validations:
+  required: false
+- type: dropdown
+  id: associated-project
+  attributes:
+  label: Tell us the project / group you are associated with
+  description: Tell us the project / group you are associated with
+  options:
+  - Community (Default)
+  - Project ServiceMesh
+  - Project Mazinger
+  - Project Watch
+  validations:
+  required: true
+- type: dropdown
+  id: operating system
+  attributes:
+  label: What is your operating system?
+  multiple: false
+  options:
+  - Linux
+  - MacOS
+- type: textarea
+  id: additional-info
+  attributes:
+  label: Any additional / relevant info
+  description: Any additional / relevant info.
+  value: "Not Applicable"
+  validations:
+  required: false


### PR DESCRIPTION
Current issue templates are using markdown as the means of getting input from the user. It is textual and the experience is very mundane.

Migrate issue templates to GitHub form schema for a better user experience while creating issues.