### PR TITLE
NPT-545 Graphql server is build with different version of gofuzz package

### DIFF
--- a/cli/pkg/common/values.yaml
+++ b/cli/pkg/common/values.yaml
@@ -3,4 +3,4 @@ nexusAppTemplates:
 nexusDatamodelTemplates:
   version: v0.0.22
 nexusRuntime:
-  version: v0.2.40
+  version: v0.2.41


### PR DESCRIPTION
as we use plugin based mechanism to load graphql binaries as importable , we are seeing errors due to gofuzz package being incompatible with graphqlserver

bumping up to latest gofuzz (v1.2.0) in graphqlserver to make it compatible
bumping up nexus-runtime with latest graphql image