### PR TITLE
NPT-173: JSON and YAML tags are not added for nested structs

### DIFF
--- a/compiler/example/output/_rendered_templates/apis/config.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/_rendered_templates/apis/config.tsm.tanzu.vmware.com/v1/types.go
@@ -182,25 +182,25 @@ type DomainList struct {
 
 // +k8s:openapi-gen=true
 type ClusterNamespace struct {
-	Cluster   MatchCondition
-	Namespace MatchCondition
+	Cluster   MatchCondition `json:"cluster" yaml:"cluster"`
+	Namespace MatchCondition `json:"namespace" yaml:"namespace"`
 }
 
 // +k8s:openapi-gen=true
 type MatchCondition struct {
-	Name string
-	Type gnstsmtanzuvmwarecomv1.Host
+	Name string                      `json:"name" yaml:"name"`
+	Type gnstsmtanzuvmwarecomv1.Host `json:"type" yaml:"type"`
 }
 
 // +k8s:openapi-gen=true
 type Cluster struct {
-	Name string
-	MyID int
+	Name string `json:"name" yaml:"name"`
+	MyID int    `json:"myID" yaml:"myID"`
 }
 
 // +k8s:openapi-gen=true
 type CrossPackageTester struct {
-	Test gnstsmtanzuvmwarecomv1.MyStr
+	Test gnstsmtanzuvmwarecomv1.MyStr `json:"test" yaml:"test"`
 }
 
 // +k8s:openapi-gen=true

--- a/compiler/example/output/_rendered_templates/apis/gns.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/_rendered_templates/apis/gns.tsm.tanzu.vmware.com/v1/types.go
@@ -332,87 +332,87 @@ type AdditionalGnsDataList struct {
 
 // +k8s:openapi-gen=true
 type RandomDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type RandomStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 // +k8s:openapi-gen=true
 type HostPort struct {
-	Host Host
-	Port Port
+	Host Host `json:"host" yaml:"host"`
+	Port Port `json:"port" yaml:"port"`
 }
 
 // +k8s:openapi-gen=true
 type ReplicationSource struct {
-	Kind SourceKind
+	Kind SourceKind `json:"kind" yaml:"kind"`
 }
 
 // +k8s:openapi-gen=true
 type gnsQueryFilters struct {
-	StartTime           string
-	EndTime             string
-	Interval            string
-	IsServiceDeployment bool
-	StartVal            int
+	StartTime           string `json:"startTime" yaml:"startTime"`
+	EndTime             string `json:"endTime" yaml:"endTime"`
+	Interval            string `json:"interval" yaml:"interval"`
+	IsServiceDeployment bool   `json:"isServiceDeployment" yaml:"isServiceDeployment"`
+	StartVal            int    `json:"startVal" yaml:"startVal"`
 }
 
 // +k8s:openapi-gen=true
 type metricsFilers struct {
-	StartTime    string
-	EndTime      string
-	TimeInterval string
-	SomeUserArg1 string
-	SomeUserArg2 int
-	SomeUserArg3 bool
+	StartTime    string `json:"startTime" yaml:"startTime"`
+	EndTime      string `json:"endTime" yaml:"endTime"`
+	TimeInterval string `json:"timeInterval" yaml:"timeInterval"`
+	SomeUserArg1 string `json:"someUserArg1" yaml:"someUserArg1"`
+	SomeUserArg2 int    `json:"someUserArg2" yaml:"someUserArg2"`
+	SomeUserArg3 bool   `json:"someUserArg3" yaml:"someUserArg3"`
 }
 
 // +k8s:openapi-gen=true
 type ServiceSegmentRef struct {
-	Field1 string
-	Field2 string
+	Field1 string `json:"field1" yaml:"field1"`
+	Field2 string `json:"field2" yaml:"field2"`
 }
 
 // +k8s:openapi-gen=true
 type Description struct {
-	Color     string
-	Version   string
-	ProjectId string
-	TestAns   []Answer
-	Instance  Instance
-	HostPort  HostPort
+	Color     string   `json:"color" yaml:"color"`
+	Version   string   `json:"version" yaml:"version"`
+	ProjectId string   `json:"projectId" yaml:"projectId"`
+	TestAns   []Answer `json:"testAns" yaml:"testAns"`
+	Instance  Instance `json:"instance" yaml:"instance"`
+	HostPort  HostPort `json:"hostPort" yaml:"hostPort"`
 }
 
 // +k8s:openapi-gen=true
 type Answer struct {
-	Name string
+	Name string `json:"name" yaml:"name"`
 }
 
 // +k8s:openapi-gen=true
 type GnsState struct {
-	Working     bool
-	Temperature int
+	Working     bool `json:"working" yaml:"working"`
+	Temperature int  `json:"temperature" yaml:"temperature"`
 }
 
 // +k8s:openapi-gen=true
 type AdditionalDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type AdditionalStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 type RandomConst1 string

--- a/compiler/example/output/_rendered_templates/apis/policypkg.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/_rendered_templates/apis/policypkg.tsm.tanzu.vmware.com/v1/types.go
@@ -237,59 +237,59 @@ type RandomPolicyDataList struct {
 
 // +k8s:openapi-gen=true
 type AdditionalDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type AdditionalStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 // +k8s:openapi-gen=true
 type ACPStatus struct {
-	StatusABC int
-	StatusXYZ int
+	StatusABC int `json:"statusABC" yaml:"statusABC"`
+	StatusXYZ int `json:"statusXYZ" yaml:"statusXYZ"`
 }
 
 // +k8s:openapi-gen=true
 type ResourceGroupRef struct {
-	Name string
-	Type string
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
 }
 
 // +k8s:openapi-gen=true
 type ACPSvcGroupLinkInfo struct {
-	ServiceName string
-	ServiceType string
+	ServiceName string `json:"serviceName" yaml:"serviceName"`
+	ServiceType string `json:"serviceType" yaml:"serviceType"`
 }
 
 // +k8s:openapi-gen=true
 type PolicyCfgAction struct {
-	Action PolicyActionType `json:"action" mapstructure:"action"`
+	Action PolicyActionType `json:"action" mapstructure:"action" yaml:"action"`
 }
 
 // +k8s:openapi-gen=true
 type ResourceGroupID struct {
-	Name string `json:"name" mapstruction:"name"`
-	Type string `json:"type" mapstruction:"type"`
+	Name string `json:"name" mapstruction:"name" yaml:"name"`
+	Type string `json:"type" mapstruction:"type" yaml:"type"`
 }
 
 // +k8s:openapi-gen=true
 type RandomDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type RandomStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 type TempConst1 string

--- a/compiler/example/output/_rendered_templates/apis/root.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/_rendered_templates/apis/root.tsm.tanzu.vmware.com/v1/types.go
@@ -72,14 +72,14 @@ type RootList struct {
 
 // +k8s:openapi-gen=true
 type NonNexusType struct {
-	Test int
+	Test int `json:"test" yaml:"test"`
 }
 
 // +k8s:openapi-gen=true
 type queryFilters struct {
-	StartTime           string
-	EndTime             string
-	Interval            string
-	IsServiceDeployment bool
-	StartVal            int
+	StartTime           string `json:"startTime" yaml:"startTime"`
+	EndTime             string `json:"endTime" yaml:"endTime"`
+	Interval            string `json:"interval" yaml:"interval"`
+	IsServiceDeployment bool   `json:"isServiceDeployment" yaml:"isServiceDeployment"`
+	StartVal            int    `json:"startVal" yaml:"startVal"`
 }

--- a/compiler/example/output/generated/apis/config.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/generated/apis/config.tsm.tanzu.vmware.com/v1/types.go
@@ -182,25 +182,25 @@ type DomainList struct {
 
 // +k8s:openapi-gen=true
 type ClusterNamespace struct {
-	Cluster   MatchCondition
-	Namespace MatchCondition
+	Cluster   MatchCondition `json:"cluster" yaml:"cluster"`
+	Namespace MatchCondition `json:"namespace" yaml:"namespace"`
 }
 
 // +k8s:openapi-gen=true
 type MatchCondition struct {
-	Name string
-	Type gnstsmtanzuvmwarecomv1.Host
+	Name string                      `json:"name" yaml:"name"`
+	Type gnstsmtanzuvmwarecomv1.Host `json:"type" yaml:"type"`
 }
 
 // +k8s:openapi-gen=true
 type Cluster struct {
-	Name string
-	MyID int
+	Name string `json:"name" yaml:"name"`
+	MyID int    `json:"myID" yaml:"myID"`
 }
 
 // +k8s:openapi-gen=true
 type CrossPackageTester struct {
-	Test gnstsmtanzuvmwarecomv1.MyStr
+	Test gnstsmtanzuvmwarecomv1.MyStr `json:"test" yaml:"test"`
 }
 
 // +k8s:openapi-gen=true

--- a/compiler/example/output/generated/apis/gns.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/generated/apis/gns.tsm.tanzu.vmware.com/v1/types.go
@@ -332,87 +332,87 @@ type AdditionalGnsDataList struct {
 
 // +k8s:openapi-gen=true
 type RandomDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type RandomStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 // +k8s:openapi-gen=true
 type HostPort struct {
-	Host Host
-	Port Port
+	Host Host `json:"host" yaml:"host"`
+	Port Port `json:"port" yaml:"port"`
 }
 
 // +k8s:openapi-gen=true
 type ReplicationSource struct {
-	Kind SourceKind
+	Kind SourceKind `json:"kind" yaml:"kind"`
 }
 
 // +k8s:openapi-gen=true
 type gnsQueryFilters struct {
-	StartTime           string
-	EndTime             string
-	Interval            string
-	IsServiceDeployment bool
-	StartVal            int
+	StartTime           string `json:"startTime" yaml:"startTime"`
+	EndTime             string `json:"endTime" yaml:"endTime"`
+	Interval            string `json:"interval" yaml:"interval"`
+	IsServiceDeployment bool   `json:"isServiceDeployment" yaml:"isServiceDeployment"`
+	StartVal            int    `json:"startVal" yaml:"startVal"`
 }
 
 // +k8s:openapi-gen=true
 type metricsFilers struct {
-	StartTime    string
-	EndTime      string
-	TimeInterval string
-	SomeUserArg1 string
-	SomeUserArg2 int
-	SomeUserArg3 bool
+	StartTime    string `json:"startTime" yaml:"startTime"`
+	EndTime      string `json:"endTime" yaml:"endTime"`
+	TimeInterval string `json:"timeInterval" yaml:"timeInterval"`
+	SomeUserArg1 string `json:"someUserArg1" yaml:"someUserArg1"`
+	SomeUserArg2 int    `json:"someUserArg2" yaml:"someUserArg2"`
+	SomeUserArg3 bool   `json:"someUserArg3" yaml:"someUserArg3"`
 }
 
 // +k8s:openapi-gen=true
 type ServiceSegmentRef struct {
-	Field1 string
-	Field2 string
+	Field1 string `json:"field1" yaml:"field1"`
+	Field2 string `json:"field2" yaml:"field2"`
 }
 
 // +k8s:openapi-gen=true
 type Description struct {
-	Color     string
-	Version   string
-	ProjectId string
-	TestAns   []Answer
-	Instance  Instance
-	HostPort  HostPort
+	Color     string   `json:"color" yaml:"color"`
+	Version   string   `json:"version" yaml:"version"`
+	ProjectId string   `json:"projectId" yaml:"projectId"`
+	TestAns   []Answer `json:"testAns" yaml:"testAns"`
+	Instance  Instance `json:"instance" yaml:"instance"`
+	HostPort  HostPort `json:"hostPort" yaml:"hostPort"`
 }
 
 // +k8s:openapi-gen=true
 type Answer struct {
-	Name string
+	Name string `json:"name" yaml:"name"`
 }
 
 // +k8s:openapi-gen=true
 type GnsState struct {
-	Working     bool
-	Temperature int
+	Working     bool `json:"working" yaml:"working"`
+	Temperature int  `json:"temperature" yaml:"temperature"`
 }
 
 // +k8s:openapi-gen=true
 type AdditionalDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type AdditionalStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 type RandomConst1 string

--- a/compiler/example/output/generated/apis/policypkg.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/generated/apis/policypkg.tsm.tanzu.vmware.com/v1/types.go
@@ -237,59 +237,59 @@ type RandomPolicyDataList struct {
 
 // +k8s:openapi-gen=true
 type AdditionalDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type AdditionalStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 // +k8s:openapi-gen=true
 type ACPStatus struct {
-	StatusABC int
-	StatusXYZ int
+	StatusABC int `json:"statusABC" yaml:"statusABC"`
+	StatusXYZ int `json:"statusXYZ" yaml:"statusXYZ"`
 }
 
 // +k8s:openapi-gen=true
 type ResourceGroupRef struct {
-	Name string
-	Type string
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
 }
 
 // +k8s:openapi-gen=true
 type ACPSvcGroupLinkInfo struct {
-	ServiceName string
-	ServiceType string
+	ServiceName string `json:"serviceName" yaml:"serviceName"`
+	ServiceType string `json:"serviceType" yaml:"serviceType"`
 }
 
 // +k8s:openapi-gen=true
 type PolicyCfgAction struct {
-	Action PolicyActionType `json:"action" mapstructure:"action"`
+	Action PolicyActionType `json:"action" mapstructure:"action" yaml:"action"`
 }
 
 // +k8s:openapi-gen=true
 type ResourceGroupID struct {
-	Name string `json:"name" mapstruction:"name"`
-	Type string `json:"type" mapstruction:"type"`
+	Name string `json:"name" mapstruction:"name" yaml:"name"`
+	Type string `json:"type" mapstruction:"type" yaml:"type"`
 }
 
 // +k8s:openapi-gen=true
 type RandomDescription struct {
-	DiscriptionA string
-	DiscriptionB string
-	DiscriptionC string
-	DiscriptionD string
+	DiscriptionA string `json:"discriptionA" yaml:"discriptionA"`
+	DiscriptionB string `json:"discriptionB" yaml:"discriptionB"`
+	DiscriptionC string `json:"discriptionC" yaml:"discriptionC"`
+	DiscriptionD string `json:"discriptionD" yaml:"discriptionD"`
 }
 
 // +k8s:openapi-gen=true
 type RandomStatus struct {
-	StatusX int
-	StatusY int
+	StatusX int `json:"statusX" yaml:"statusX"`
+	StatusY int `json:"statusY" yaml:"statusY"`
 }
 
 type TempConst1 string

--- a/compiler/example/output/generated/apis/root.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/generated/apis/root.tsm.tanzu.vmware.com/v1/types.go
@@ -72,14 +72,14 @@ type RootList struct {
 
 // +k8s:openapi-gen=true
 type NonNexusType struct {
-	Test int
+	Test int `json:"test" yaml:"test"`
 }
 
 // +k8s:openapi-gen=true
 type queryFilters struct {
-	StartTime           string
-	EndTime             string
-	Interval            string
-	IsServiceDeployment bool
-	StartVal            int
+	StartTime           string `json:"startTime" yaml:"startTime"`
+	EndTime             string `json:"endTime" yaml:"endTime"`
+	Interval            string `json:"interval" yaml:"interval"`
+	IsServiceDeployment bool   `json:"isServiceDeployment" yaml:"isServiceDeployment"`
+	StartVal            int    `json:"startVal" yaml:"startVal"`
 }

--- a/compiler/example/output/generated/crds/config_config.yaml
+++ b/compiler/example/output/generated/crds/config_config.yaml
@@ -60,29 +60,29 @@ spec:
               clusterNamespaces:
                 items:
                   properties:
-                    Cluster:
+                    cluster:
                       properties:
-                        Name:
+                        name:
                           type: string
-                        Type:
+                        type:
                           type: string
                       required:
-                      - Name
-                      - Type
+                      - name
+                      - type
                       type: object
-                    Namespace:
+                    namespace:
                       properties:
-                        Name:
+                        name:
                           type: string
-                        Type:
+                        type:
                           type: string
                       required:
-                      - Name
-                      - Type
+                      - name
+                      - type
                       type: object
                   required:
-                  - Cluster
-                  - Namespace
+                  - cluster
+                  - namespace
                   type: object
                 type: array
               dNSGvk:

--- a/compiler/example/output/generated/crds/config_domain.yaml
+++ b/compiler/example/output/generated/crds/config_domain.yaml
@@ -62,14 +62,14 @@ spec:
                 type: string
               pointStruct:
                 properties:
-                  MyID:
+                  myID:
                     format: int32
                     type: integer
-                  Name:
+                  name:
                     type: string
                 required:
-                - Name
-                - MyID
+                - name
+                - myID
                 type: object
               sliceOfArrPoints:
                 items:

--- a/compiler/example/output/generated/crds/gns_additionalgnsdata.yaml
+++ b/compiler/example/output/generated/crds/gns_additionalgnsdata.yaml
@@ -40,19 +40,19 @@ spec:
             properties:
               description:
                 properties:
-                  DiscriptionA:
+                  discriptionA:
                     type: string
-                  DiscriptionB:
+                  discriptionB:
                     type: string
-                  DiscriptionC:
+                  discriptionC:
                     type: string
-                  DiscriptionD:
+                  discriptionD:
                     type: string
                 required:
-                - DiscriptionA
-                - DiscriptionB
-                - DiscriptionC
-                - DiscriptionD
+                - discriptionA
+                - discriptionB
+                - discriptionC
+                - discriptionD
                 type: object
             required:
             - description
@@ -73,15 +73,15 @@ spec:
                 type: object
               status:
                 properties:
-                  StatusX:
+                  statusX:
                     format: int32
                     type: integer
-                  StatusY:
+                  statusY:
                     format: int32
                     type: integer
                 required:
-                - StatusX
-                - StatusY
+                - statusX
+                - statusY
                 type: object
             type: object
         type: object

--- a/compiler/example/output/generated/crds/gns_gns.yaml
+++ b/compiler/example/output/generated/crds/gns_gns.yaml
@@ -40,42 +40,42 @@ spec:
             properties:
               description:
                 properties:
-                  Color:
+                  color:
                     type: string
-                  HostPort:
+                  hostPort:
                     properties:
-                      Host:
+                      host:
                         type: string
-                      Port:
+                      port:
                         format: int32
                         type: integer
                     required:
-                    - Host
-                    - Port
+                    - host
+                    - port
                     type: object
-                  Instance:
+                  instance:
                     format: float
                     type: number
-                  ProjectId:
+                  projectId:
                     type: string
-                  TestAns:
+                  testAns:
                     items:
                       properties:
-                        Name:
+                        name:
                           type: string
                       required:
-                      - Name
+                      - name
                       type: object
                     type: array
-                  Version:
+                  version:
                     type: string
                 required:
-                - Color
-                - Version
-                - ProjectId
-                - TestAns
-                - Instance
-                - HostPort
+                - color
+                - version
+                - projectId
+                - testAns
+                - instance
+                - hostPort
                 type: object
               differentSpec:
                 type: object
@@ -173,88 +173,88 @@ spec:
                 type: string
               otherDescription:
                 properties:
-                  Color:
+                  color:
                     type: string
-                  HostPort:
+                  hostPort:
                     properties:
-                      Host:
+                      host:
                         type: string
-                      Port:
+                      port:
                         format: int32
                         type: integer
                     required:
-                    - Host
-                    - Port
+                    - host
+                    - port
                     type: object
-                  Instance:
+                  instance:
                     format: float
                     type: number
-                  ProjectId:
+                  projectId:
                     type: string
-                  TestAns:
+                  testAns:
                     items:
                       properties:
-                        Name:
+                        name:
                           type: string
                       required:
-                      - Name
+                      - name
                       type: object
                     type: array
-                  Version:
+                  version:
                     type: string
                 required:
-                - Color
-                - Version
-                - ProjectId
-                - TestAns
-                - Instance
-                - HostPort
+                - color
+                - version
+                - projectId
+                - testAns
+                - instance
+                - hostPort
                 type: object
               port:
                 format: int32
                 type: integer
               serviceSegmentRef:
                 properties:
-                  Field1:
+                  field1:
                     type: string
-                  Field2:
+                  field2:
                     type: string
                 required:
-                - Field1
-                - Field2
+                - field1
+                - field2
                 type: object
               serviceSegmentRefMap:
                 additionalProperties:
                   properties:
-                    Field1:
+                    field1:
                       type: string
-                    Field2:
+                    field2:
                       type: string
                   required:
-                  - Field1
-                  - Field2
+                  - field1
+                  - field2
                   type: object
                 type: object
               serviceSegmentRefPointer:
                 properties:
-                  Field1:
+                  field1:
                     type: string
-                  Field2:
+                  field2:
                     type: string
                 required:
-                - Field1
-                - Field2
+                - field1
+                - field2
                 type: object
               serviceSegmentRefs:
                 items:
                   properties:
-                    Field1:
+                    field1:
                       type: string
-                    Field2:
+                    field2:
                       type: string
                   required:
-                  - Field1
-                  - Field2
+                  - field1
+                  - field2
                   type: object
                 type: array
               slicePointer:
@@ -294,14 +294,14 @@ spec:
                 type: object
               state:
                 properties:
-                  Temperature:
+                  temperature:
                     format: int32
                     type: integer
-                  Working:
+                  working:
                     type: boolean
                 required:
-                - Working
-                - Temperature
+                - working
+                - temperature
                 type: object
             type: object
         type: object

--- a/compiler/example/output/generated/crds/gns_randomgnsdata.yaml
+++ b/compiler/example/output/generated/crds/gns_randomgnsdata.yaml
@@ -40,19 +40,19 @@ spec:
             properties:
               description:
                 properties:
-                  DiscriptionA:
+                  discriptionA:
                     type: string
-                  DiscriptionB:
+                  discriptionB:
                     type: string
-                  DiscriptionC:
+                  discriptionC:
                     type: string
-                  DiscriptionD:
+                  discriptionD:
                     type: string
                 required:
-                - DiscriptionA
-                - DiscriptionB
-                - DiscriptionC
-                - DiscriptionD
+                - discriptionA
+                - discriptionB
+                - discriptionC
+                - discriptionD
                 type: object
             required:
             - description
@@ -73,15 +73,15 @@ spec:
                 type: object
               status:
                 properties:
-                  StatusX:
+                  statusX:
                     format: int32
                     type: integer
-                  StatusY:
+                  statusY:
                     format: int32
                     type: integer
                 required:
-                - StatusX
-                - StatusY
+                - statusX
+                - statusY
                 type: object
             type: object
         type: object

--- a/compiler/example/output/generated/crds/policypkg_acpconfig.yaml
+++ b/compiler/example/output/generated/crds/policypkg_acpconfig.yaml
@@ -108,15 +108,15 @@ spec:
                 type: object
               status:
                 properties:
-                  StatusABC:
+                  statusABC:
                     format: int32
                     type: integer
-                  StatusXYZ:
+                  statusXYZ:
                     format: int32
                     type: integer
                 required:
-                - StatusABC
-                - StatusXYZ
+                - statusABC
+                - statusXYZ
                 type: object
             type: object
         type: object

--- a/compiler/example/output/generated/crds/policypkg_additionalpolicydata.yaml
+++ b/compiler/example/output/generated/crds/policypkg_additionalpolicydata.yaml
@@ -40,19 +40,19 @@ spec:
             properties:
               description:
                 properties:
-                  DiscriptionA:
+                  discriptionA:
                     type: string
-                  DiscriptionB:
+                  discriptionB:
                     type: string
-                  DiscriptionC:
+                  discriptionC:
                     type: string
-                  DiscriptionD:
+                  discriptionD:
                     type: string
                 required:
-                - DiscriptionA
-                - DiscriptionB
-                - DiscriptionC
-                - DiscriptionD
+                - discriptionA
+                - discriptionB
+                - discriptionC
+                - discriptionD
                 type: object
             required:
             - description
@@ -73,15 +73,15 @@ spec:
                 type: object
               status:
                 properties:
-                  StatusX:
+                  statusX:
                     format: int32
                     type: integer
-                  StatusY:
+                  statusY:
                     format: int32
                     type: integer
                 required:
-                - StatusX
-                - StatusY
+                - statusX
+                - statusY
                 type: object
             type: object
         type: object

--- a/compiler/example/output/generated/crds/policypkg_randompolicydata.yaml
+++ b/compiler/example/output/generated/crds/policypkg_randompolicydata.yaml
@@ -40,19 +40,19 @@ spec:
             properties:
               description:
                 properties:
-                  DiscriptionA:
+                  discriptionA:
                     type: string
-                  DiscriptionB:
+                  discriptionB:
                     type: string
-                  DiscriptionC:
+                  discriptionC:
                     type: string
-                  DiscriptionD:
+                  discriptionD:
                     type: string
                 required:
-                - DiscriptionA
-                - DiscriptionB
-                - DiscriptionC
-                - DiscriptionD
+                - discriptionA
+                - discriptionB
+                - discriptionC
+                - discriptionD
                 type: object
             required:
             - description
@@ -73,15 +73,15 @@ spec:
                 type: object
               status:
                 properties:
-                  StatusX:
+                  statusX:
                     format: int32
                     type: integer
-                  StatusY:
+                  statusY:
                     format: int32
                     type: integer
                 required:
-                - StatusX
-                - StatusY
+                - statusX
+                - statusY
                 type: object
             type: object
         type: object

--- a/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/apis/config.tsm-tanzu.vmware.com/v1/types.go
+++ b/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/apis/config.tsm-tanzu.vmware.com/v1/types.go
@@ -74,6 +74,6 @@ type ConfigList struct {
 
 // +k8s:openapi-gen=true
 type MyStruct struct {
-	TempFiledA string
-	TempFiledB string
+	TempFiledA string `json:"tempFiledA" yaml:"tempFiledA"`
+	TempFiledB string `json:"tempFiledB" yaml:"tempFiledB"`
 }

--- a/compiler/pkg/generator/types_generator.go
+++ b/compiler/pkg/generator/types_generator.go
@@ -275,6 +275,9 @@ type {{.Name}} struct {
 		typeString := ConstructType(aliasNameMap, field)
 
 		currentTags := parser.GetFieldTags(field)
+		currentTags = parser.FillEmptyTag(currentTags, name, "json")
+		currentTags = parser.FillEmptyTag(currentTags, name, "yaml")
+
 		if currentTags != nil && currentTags.Len() > 0 {
 			specDef.Fields += typeString
 			specDef.Fields += " " + fmt.Sprintf("`%s`", currentTags.String()) + "\n"

--- a/compiler/pkg/parser/pkg.go
+++ b/compiler/pkg/parser/pkg.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/util"
 	"go/ast"
 	"go/printer"
 	"go/token"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/fatih/structtag"
 	log "github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/util"
 )
 
 type Packages map[string]Package

--- a/compiler/pkg/parser/pkg.go
+++ b/compiler/pkg/parser/pkg.go
@@ -593,7 +593,10 @@ func FillEmptyTag(ts *structtag.Tags, n, tag string) *structtag.Tags {
 		Name:    util.GetTag(n),
 		Options: nil,
 	}
-	ts.Set(&jt)
+	err := ts.Set(&jt)
+	if err != nil {
+		log.Fatalf("Failed to set tag: %v", err)
+	}
 
 	return ts
 }

--- a/compiler/pkg/parser/pkg.go
+++ b/compiler/pkg/parser/pkg.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/util"
 	"go/ast"
 	"go/printer"
 	"go/token"
@@ -572,6 +573,29 @@ func GetFieldTags(f *ast.Field) *structtag.Tags {
 	}
 
 	return ParseFieldTags(f.Tag.Value)
+}
+
+func FillEmptyTag(ts *structtag.Tags, n, tag string) *structtag.Tags {
+
+	if ts == nil {
+		ts = &structtag.Tags{}
+	}
+	for _, t := range ts.Tags() {
+		if t.Key == tag {
+			return ts
+		}
+	}
+	if len(n) < 2 {
+		return ts
+	}
+	jt := structtag.Tag{
+		Key:     tag,
+		Name:    util.GetTag(n),
+		Options: nil,
+	}
+	ts.Set(&jt)
+
+	return ts
 }
 
 func GetFieldType(f *ast.Field) string {

--- a/compiler/pkg/parser/pkg_test.go
+++ b/compiler/pkg/parser/pkg_test.go
@@ -1,13 +1,13 @@
 package parser_test
 
 import (
-	"github.com/fatih/structtag"
 	"go/ast"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/fatih/structtag"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/config"
 	generator "github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/generator"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/parser"

--- a/compiler/pkg/parser/pkg_test.go
+++ b/compiler/pkg/parser/pkg_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"github.com/fatih/structtag"
 	"go/ast"
 
 	. "github.com/onsi/ginkgo"
@@ -117,6 +118,26 @@ var _ = Describe("Pkg tests", func() {
 		childFields := parser.GetChildFields(nodes[0])
 		fieldType := parser.GetFieldType(childFields[0])
 		Expect(fieldType).To(Equal("config.Config"))
+	})
+
+	It("should fill empty tag", func() {
+		ts := structtag.Tags{}
+		ts = *parser.FillEmptyTag(&ts, "name", "tag")
+		tn, _ := ts.Get("tag")
+		Expect(tn.Name).To(Equal("name"))
+	})
+
+	It("should not modify existing tag", func() {
+		ts := structtag.Tags{}
+		t := structtag.Tag{
+			Key:     "tag",
+			Name:    "diff_name",
+			Options: nil,
+		}
+		ts.Set(&t)
+		parser.FillEmptyTag(&ts, "name", "tag")
+		tn, _ := ts.Get("tag")
+		Expect(tn.Name).To(Equal("diff_name"))
 	})
 
 	It("should get pointer field type", func() {

--- a/compiler/pkg/parser/pkg_test.go
+++ b/compiler/pkg/parser/pkg_test.go
@@ -134,9 +134,10 @@ var _ = Describe("Pkg tests", func() {
 			Name:    "diff_name",
 			Options: nil,
 		}
-		ts.Set(&t)
+		err := ts.Set(&t)
 		parser.FillEmptyTag(&ts, "name", "tag")
 		tn, _ := ts.Get("tag")
+		Expect(err).To(Not(HaveOccurred()))
 		Expect(tn.Name).To(Equal("diff_name"))
 	})
 


### PR DESCRIPTION
NPT-173: JSON and YAML tags are not added for nested structs

Nested struct fields in nexus.Node structs, are not populating correctly in CRD. Generated yaml and json files should use camelCase for their fields, which doesn't work if they are not specifically provided. 

This change automatically adds tags misssing tags, which solves the issue of case in output files