### PR TITLE
add ignore feature with test

### DIFF
--- a/compiler/example/datamodel/ignored/config.go
+++ b/compiler/example/datamodel/ignored/config.go
@@ -1,0 +1,7 @@
+package ignored
+
+import "github.com/vmware-tanzu/graph-framework-for-microservices/compiler/example/datamodel/config/gns"
+
+type Config struct {
+	GNS gns.Gns `nexus:"child"`
+}

--- a/compiler/example/nexus-sdk.yaml
+++ b/compiler/example/nexus-sdk.yaml
@@ -1,1 +1,3 @@
 groupName: "tsm.tanzu.vmware.com"
+ignoredDirs:
+  - "ignored"

--- a/compiler/pkg/config/config.go
+++ b/compiler/pkg/config/config.go
@@ -11,8 +11,9 @@ import (
 var ConfigInstance *Config
 
 type Config struct {
-	GroupName     string `yaml:"groupName"`
-	CrdModulePath string `yaml:"crdModulePath"`
+	GroupName     string   `yaml:"groupName"`
+	CrdModulePath string   `yaml:"crdModulePath"`
+	IgnoredDirs   []string `yaml:"ignoredDirs"`
 }
 
 func LoadConfig(configFile string) (*Config, error) {

--- a/compiler/pkg/parser/pkg_parser.go
+++ b/compiler/pkg/parser/pkg_parser.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/config"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -27,6 +29,14 @@ func ParseDSLPkg(startPath string) Packages {
 				log.Infof("Ignoring vendor directory...")
 				return filepath.SkipDir
 			}
+
+			for _, f := range config.ConfigInstance.IgnoredDirs {
+				if info.Name() == f {
+					log.Infof(fmt.Sprintf("Ignoring %v directory from config", f))
+					return filepath.SkipDir
+				}
+			}
+
 			fileset := token.NewFileSet()
 			pkgs, err := parser.ParseDir(fileset, path, nil, parser.ParseComments)
 			if err != nil {

--- a/compiler/pkg/parser/pkg_parser_test.go
+++ b/compiler/pkg/parser/pkg_parser_test.go
@@ -3,6 +3,7 @@ package parser_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/config"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/parser"
 )
 
@@ -11,5 +12,18 @@ var _ = Describe("Pkg parser tests", func() {
 		pkgs := parser.ParseDSLPkg(exampleDSLPath)
 		_, ok := pkgs["github.com/vmware-tanzu/graph-framework-for-microservices/compiler/example/datamodel"]
 		Expect(ok).To(BeTrue())
+	})
+	It("should ignore ignored dirs", func() {
+		config.ConfigInstance.IgnoredDirs = []string{"ignored"}
+		pkgs := parser.ParseDSLPkg(exampleDSLPath)
+		ignored_imported := false
+		for _, pkg := range pkgs {
+			for _, f := range config.ConfigInstance.IgnoredDirs {
+				if pkg.Name == f {
+					ignored_imported = true
+				}
+			}
+		}
+		Expect(ignored_imported).To(BeFalse())
 	})
 })


### PR DESCRIPTION
NPT-591: Add ignore file to compiler

User should be able to add packages which will be ignored by parses (like build and vendor dirs, which are hardcoded to be ignored)

This change allows adding list of directories ("ignoredDirs") in yaml config file, which will be ignored by parser.