### PR TITLE
[NPT-678] Add script to download and install nexus cli 

### DIFF
--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+while [[ $# -gt 0 ]]; do
+ case $1 in
+    --repository)
+       REPOSITORY="$2"
+       shift
+       shift
+       ;;
+    --version)
+       VERSION="$2"
+       shift
+       shift
+       ;;
+    --dst_dir)
+       DST_DIR="$2"
+       shift
+       shift
+       ;;
+    --help)
+       help
+       exit 0
+       ;;
+    *)
+       echo "Input not understood. See '--help' for information on using this command."
+       exit 1
+       ;;
+  esac
+done
+
+if [ -z "$REPOSITORY" ]
+then
+   REPOSITORY="gcr.io/nsx-sm/nexus/nexus-cli"
+fi
+
+if [ -z "$VERSION" ]
+then
+   #VERSION="v0.0.134"
+   VERSION="latest"
+fi
+
+if [ -z "$DST_DIR" ]
+then
+   DST_DIR="/usr/local/bin"
+fi
+
+OS=`uname -s`
+
+docker_name="nexus-cli"
+darwin_src_path="/nexus/darwin/nexus"
+linux_src_path="/nexus/linux/nexus"
+
+docker create --name "$docker_name" ${REPOSITORY}:${VERSION}
+
+if [ "$OS" == "Darwin" ]; then
+   docker cp "${docker_name}:${darwin_src_path}" "$DST_DIR/nexus" 
+elif [ "$OS" == "Linux" ]; then
+   docker cp "${docker_name}:${linux_src_path}" "$DST_DIR/nexus" 
+else
+   echo "Unsupported OS type: ${OS}, nexus cli supported OS types are : 1) Linux and 2) Darwin"
+fi
+
+docker rm -f ${docker_name}
+

--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -64,6 +64,7 @@ docker_name="nexus-cli"
 darwin_src_path="/nexus/darwin/nexus"
 linux_src_path="/nexus/linux/nexus"
 
+docker pull ${REPOSITORY}:${VERSION} 1> /dev/null
 docker create --name "$docker_name" ${REPOSITORY}:${VERSION} 1> /dev/null
 
 if [ "$OS" == "Darwin" ]; then

--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+usage ()
+{
+   echo "======================================================================================================================"
+   echo "Download and install latest Nexus CLI: bash $0 "
+   echo "Download and install Specific Version of Nexus CLI: bash $0 --version v0.0.134"
+   echo "Download and install Specific Version of Nexus CLI in User Defined Path: bash $0 --version v0.0.134 --dst_dir /usr/local/bin"
+   echo "If --dst_dir is configured --> if the given path is required sudo persmission, please run the script with sudo bash $0"
+   echo "======================================================================================================================="
+}
+
+
 while [[ $# -gt 0 ]]; do
  case $1 in
     --repository)
@@ -19,7 +30,7 @@ while [[ $# -gt 0 ]]; do
        shift
        ;;
     --help)
-       help
+       usage
        exit 0
        ;;
     *)

--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -23,11 +23,13 @@ while [[ $# -gt 0 ]]; do
        exit 0
        ;;
     *)
-       echo "Input not understood. See '--help' for information on using this command."
+       echo "Input is invalid. See '--help' for information on using this command."
        exit 1
        ;;
   esac
 done
+
+default_path=""
 
 if [ -z "$REPOSITORY" ]
 then
@@ -36,13 +38,13 @@ fi
 
 if [ -z "$VERSION" ]
 then
-   #VERSION="v0.0.134"
    VERSION="latest"
 fi
 
 if [ -z "$DST_DIR" ]
 then
-   DST_DIR="/usr/local/bin"
+   default_path="$PWD"
+   DST_DIR="$default_path"
 fi
 
 OS=`uname -s`
@@ -51,15 +53,23 @@ docker_name="nexus-cli"
 darwin_src_path="/nexus/darwin/nexus"
 linux_src_path="/nexus/linux/nexus"
 
-docker create --name "$docker_name" ${REPOSITORY}:${VERSION}
+docker create --name "$docker_name" ${REPOSITORY}:${VERSION} 1> /dev/null
 
 if [ "$OS" == "Darwin" ]; then
    docker cp "${docker_name}:${darwin_src_path}" "$DST_DIR/nexus" 
 elif [ "$OS" == "Linux" ]; then
-   docker cp "${docker_name}:${linux_src_path}" "$DST_DIR/nexus" 
+   docker cp "${docker_name}:${linux_src_path}" "$DST_DIR/nexus"
 else
    echo "Unsupported OS type: ${OS}, nexus cli supported OS types are : 1) Linux and 2) Darwin"
 fi
 
-docker rm -f ${docker_name}
+docker rm -f ${docker_name} 1> /dev/null
+
+if [ -n "$default_path" ]
+then
+    echo -e "The nexus cli binary downloaded here: $default_path/nexus\nPlease place the nexus cli binary in the User PATH, hence it's accessible from anywhere in the shell"
+else
+    echo "The nexus cli binary downloaded here: $DST_DIR/nexus"
+fi
+
 


### PR DESCRIPTION
Add script to download the nexus cli to User given Path or default path.

The design is captured here:  https://jira.eng.vmware.com/browse/NPT-678

Example command to download and execute the script:
`curl -fsSL https://raw.githubusercontent.com/vmware-tanzu/graph-framework-for-microservices/NPT-678-nexus-cli-install/cli/get-nexus-cli.sh -o get-nexus-cli.sh

To download the latest image
bash get-nexus-cli.sh

To download a specific version
bash get-nexus-cli.sh --version v0.0.134`

