### PR TITLE
NPT-683: Graphql playground update

### DIFF
--- a/gqlgen/graphql/executor/executor.go
+++ b/gqlgen/graphql/executor/executor.go
@@ -184,7 +184,7 @@ func (e *Executor) parseQuery(ctx context.Context, stats *graphql.Stats, query s
 	stats.Validation.Start = graphql.Now()
 
 	if len(doc.Operations) == 0 {
-		err = gqlerror.Errorf("no operation provided")
+		err = gqlerror.Errorf("Please Provide Valid GraphQL Query")
 		gqlErr, _ := err.(*gqlerror.Error)
 		errcode.Set(err, errcode.ValidationFailed)
 		return nil, gqlerror.List{gqlErr}

--- a/gqlgen/graphql/playground/playground.go
+++ b/gqlgen/graphql/playground/playground.go
@@ -82,9 +82,9 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 			"endpoint":             endpoint,
 			"endpointIsAbsolute":   endpointHasScheme(endpoint),
 			"subscriptionEndpoint": getSubscriptionEndpoint(endpoint),
-			"version":              "2.0.1",
-			"cssSRI":               "sha256-hYUgpHapGug0ucdB5kG0zSipubcQOJcGjclIZke2rl8=",
-			"jsSRI":                "sha256-jMXGO5+Y4OhcHPSR34jpzpzlz4OZTlxcvaDXSWmUMRo=",
+			"version":              "2.0.7",
+			"cssSRI":               "sha256-gQryfbGYeYFxnJYnfPStPYFt0+uv8RP8Dm++eh00G9c=",
+			"jsSRI":                "sha256-qQ6pw7LwTLC+GfzN+cJsYXfVWRKH9O5o7+5H96gTJhQ=",
 			"reactSRI":             "sha256-Ipu/TQ50iCCVZBUsZyNJfxrDk0E2yhaEIz0vqI+kFG8=",
 			"reactDOMSRI":          "sha256-nbMykgB6tsOFJ7OdVmPpdqMFVk4ZsqWocT6issAPUF0=",
 		})


### PR DESCRIPTION
JIRA: https://jira.eng.vmware.com/browse/NPT-683

**PROBLEM:**
GraphQL playground throws the following error message and stacks when an empty query is executed
![image](https://user-images.githubusercontent.com/49182306/203743086-85e19151-9c9d-4650-ae89-92fc8483dfcf.png)

The response error message and stack were not at all relevant to the empty query case
```
{
  "errors": [
    {
      "message": "Invalid AST Node: undefined.",
      "stack": "Error: Invalid AST Node: undefined.\n    at o (https://cdn.jsdelivr.net/npm/graphiql@2.0.1/graphiql.min.js:1:195952)\n    at Le (https://cdn.jsdelivr.net/npm/graphiql@2.0.1/graphiql.min.js:1:233026)\n    at e.isSubscriptionWithName (https://cdn.jsdelivr.net/npm/graphiql@2.0.1/graphiql.min.js:29:466654)\n    at https://cdn.jsdelivr.net/npm/graphiql@2.0.1/graphiql.min.js:29:464369\n    at https://cdn.jsdelivr.net/npm/graphiql@2.0.1/graphiql.min.js:29:223596\n    at onClick (https://cdn.jsdelivr.net/npm/graphiql@2.0.1/graphiql.min.js:29:291953)\n    at Object.vi (https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js:202:330)\n    at ui (https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js:32:27)\n    at xi (https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js:32:81)\n    at zg (https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.production.min.js:55:403)"
    }
  ]
}
```

The problem is `GraphiQL` library used by gqlgen playground is outdated and that cause the above error and stack output

**SOLUTION:**

Update `graphiql` to the latest version `2.0.7` and update the error message

After the fix, When an empty query is executed, the following message will be displayed

![image](https://user-images.githubusercontent.com/49182306/203746997-09a34cdf-6b76-499f-9bfa-e222dc44b315.png)

