### PR TITLE
NPT-671: The `nexus datamodel build` should build docker image by default

### DIFF
--- a/docs/getting_started/Playground.md
+++ b/docs/getting_started/Playground.md
@@ -131,11 +131,6 @@ type Engineer struct {
    ```
    nexus datamodel build --name orgchart
    ```
-5. Package datamodel as docker image
-
-   ```
-   DOCKER_REPO=orgchart VERSION=latest make docker_build
-   ```
 
 ## Install Datamodel
 


### PR DESCRIPTION
Removed datamodel  docker pkg step, since the nexus datamodel build will do this step