### PR TITLE
NPT-695: Delete any docker with nexus-cli is

### DIFF
--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -62,6 +62,8 @@ docker_name="nexus-cli"
 darwin_src_path="/nexus/darwin/nexus"
 linux_src_path="/nexus/linux/nexus"
 
+docker rm -f ${docker_name} &> /dev/null
+
 docker pull ${REPOSITORY}:${VERSION} 1> /dev/null
 docker create --name "$docker_name" ${REPOSITORY}:${VERSION} 1> /dev/null
 

--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -76,6 +76,7 @@ else
 fi
 
 docker rm -f ${docker_name} 1> /dev/null
+docker rmi "${REPOSITORY}" &> /dev/null
 
 echo "The nexus cli binary downloaded here: $DST_DIR/nexus"
 


### PR DESCRIPTION
closes #73 

For any reason `bash get-nexus-cli.sh` failed, the next re-try might fail if the previous docker is running. So added a step to remove the docker before creating new docker with nexus-cli