### PR TITLE
#74 NPT-696: Remove hardcoded paths from playground 

### DIFF
--- a/docs/getting_started/Playground.md
+++ b/docs/getting_started/Playground.md
@@ -159,7 +159,7 @@ type Engineer struct {
 	Name        string
 	Designation string
 }
-' > $HOME/test-datamodel/orgchart/root.go
+' > $WORKDIR/test-datamodel/orgchart/root.go
 ```
 
 4. Compile datamodel

--- a/docs/getting_started/Playground.md
+++ b/docs/getting_started/Playground.md
@@ -8,6 +8,8 @@ The goal is to give you a taste on the most interesting and impactful aspects of
 
 [Install Nexus CLI](#install-nexus-cli)
 
+[Setup Workspace](#setup-workspace)
+
 [Build a datamodel](#build-a-datamodel)
 
 [Install datamodel](#install-datamodel)
@@ -83,13 +85,18 @@ The goal is to give you a taste on the most interesting and impactful aspects of
 
     </details>
 
+## Setup Workspace
+   ```
+	export WORKDIR=$HOME/work/graph-test
+   ```
+
 ## Build a Datamodel
 
 Lets define a datamodel to implement well known facet in our work: Organization Chart
 
 1. Create a workspace directory
     ```
-    mkdir -p $HOME/test-datamodel/orgchart && cd $HOME/test-datamodel/orgchart       
+    mkdir -p $WORKDIR/test-datamodel/orgchart && cd $WORKDIR/test-datamodel/orgchart       
     ```
 
 2. Initialize workspace to specify datamodel


### PR DESCRIPTION
All the getting started documents have hardcoded paths
mkdir -p $HOME/test-datamodel/orgchart && cd $HOME/test-datamodel/orgchart

As requested the paths are to be user-defined
export WORKDIR=$HOME/work/graph-test
mkdir -p $WORKDIR/test-datamodel/orgchart && cd $WORKDIR/test-datamodel/orgchart