### PR TITLE
NPT-728: Use subscribe API feature of nexus-client library in graphql

### DIFF
--- a/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
@@ -68,8 +68,8 @@ func getRootResolver() (*model.RootRoot, error) {
 
 	vRoot, err := nc.GetRootRoot(context.TODO())
 	if err != nil {
-	    log.Errorf("[getRootResolver]Error getting Root node %s", err)
-        return nil, nil
+		log.Errorf("[getRootResolver]Error getting Root node %s", err)
+		return nil, nil
 	}
 	dn := vRoot.DisplayName()
 parentLabels := map[string]interface{}{"roots.root.tsm.tanzu.vmware.com":dn}

--- a/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
@@ -55,16 +55,16 @@ func getK8sAPIEndpointConfig() *rest.Config {
 // PKG: Root, NODE: Root
 //////////////////////////////////////
 func getRootResolver() (*model.RootRoot, error) {
-    if nc == nil {
-       k8sApiConfig := getK8sAPIEndpointConfig()
-	    nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-	    if err != nil {
-            return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-	    }
+	if nc == nil {
+		k8sApiConfig := getK8sAPIEndpointConfig()
+		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
+		}
 		nc = nexusClient
 		nc.SubscribeAll()
 		log.Debugf("Subscribed to all nodes in datamodel")
-    }
+	}
 
 	vRoot, err := nc.GetRootRoot(context.TODO())
 	if err != nil {

--- a/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
@@ -62,6 +62,8 @@ func getRootResolver() (*model.RootRoot, error) {
             return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 	    }
 	nc = nexusClient
+	nc.SubscribeAll()
+	log.Debugf("Subscribe api is called for all the nodes.")
 }
 
 	vRoot, err := nc.GetRootRoot(context.TODO())

--- a/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
@@ -61,10 +61,10 @@ func getRootResolver() (*model.RootRoot, error) {
 	    if err != nil {
             return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 	    }
-	nc = nexusClient
-	nc.SubscribeAll()
-	log.Debugf("Subscribe api is called for all the nodes.")
-}
+		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribed to all nodes in datamodel")
+    }
 
 	vRoot, err := nc.GetRootRoot(context.TODO())
 	if err != nil {

--- a/compiler/example/output/generated/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/generated/nexus-gql/graph/graphqlResolver.go
@@ -70,7 +70,7 @@ func getRootResolver() (*model.RootRoot, error) {
 		}
 		nc = nexusClient
 		nc.SubscribeAll()
-		log.Debugf("Subscribe api is called for all the nodes.")
+		log.Debugf("Subscribed to all nodes in datamodel")
 	}
 
 	vRoot, err := nc.GetRootRoot(context.TODO())

--- a/compiler/example/output/generated/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/generated/nexus-gql/graph/graphqlResolver.go
@@ -69,6 +69,8 @@ func getRootResolver() (*model.RootRoot, error) {
 			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 		}
 		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribe api is called for all the nodes.")
 	}
 
 	vRoot, err := nc.GetRootRoot(context.TODO())

--- a/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
@@ -55,21 +55,21 @@ func getK8sAPIEndpointConfig() *rest.Config {
 // PKG: Config, NODE: Config
 //////////////////////////////////////
 func getRootResolver() (*model.ConfigConfig, error) {
-    if nc == nil {
-       k8sApiConfig := getK8sAPIEndpointConfig()
-	    nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-	    if err != nil {
-            return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-	    }
+	if nc == nil {
+		k8sApiConfig := getK8sAPIEndpointConfig()
+		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
+		}
 		nc = nexusClient
 		nc.SubscribeAll()
 		log.Debugf("Subscribed to all nodes in datamodel")
-    }
+	}
 
 	vConfig, err := nc.GetConfigConfig(context.TODO())
 	if err != nil {
-	    log.Errorf("[getRootResolver]Error getting Config node %s", err)
-        return nil, nil
+		log.Errorf("[getRootResolver]Error getting Config node %s", err)
+		return nil, nil
 	}
 	dn := vConfig.DisplayName()
 parentLabels := map[string]interface{}{"configs.config.tsm-tanzu.vmware.com":dn}

--- a/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
@@ -61,10 +61,10 @@ func getRootResolver() (*model.ConfigConfig, error) {
 	    if err != nil {
             return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 	    }
-	nc = nexusClient
-	nc.SubscribeAll()
-	log.Debugf("Subscribe api is called for all the nodes.")
-}
+		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribed to all nodes in datamodel")
+    }
 
 	vConfig, err := nc.GetConfigConfig(context.TODO())
 	if err != nil {

--- a/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
@@ -62,6 +62,8 @@ func getRootResolver() (*model.ConfigConfig, error) {
             return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 	    }
 	nc = nexusClient
+	nc.SubscribeAll()
+	log.Debugf("Subscribe api is called for all the nodes.")
 }
 
 	vConfig, err := nc.GetConfigConfig(context.TODO())

--- a/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
+++ b/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
@@ -71,8 +71,8 @@ func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
 
 	v{{$node.NodeName}}, err := nc.Get{{$node.PkgName}}{{$node.NodeName}}(context.TODO())
 	if err != nil {
-	    log.Errorf("[getRootResolver]Error getting {{$node.NodeName}} node %s", err)
-        return nil, nil
+		log.Errorf("[getRootResolver]Error getting {{$node.NodeName}} node %s", err)
+		return nil, nil
 	}
 	{{ $node.Alias }}
 	{{ $node.ReturnType }}
@@ -98,7 +98,7 @@ func getRootResolver(id *string) ([]*model.{{$node.PkgName}}{{$node.NodeName}}, 
 
 	var v{{$node.NodeName}}List []*model.{{$node.PkgName}}{{$node.NodeName}}
 	if id != nil && *id != "" {
-	    log.Debugf("[getRootResolver]Id: %q", *id)
+		log.Debugf("[getRootResolver]Id: %q", *id)
 		v{{$node.NodeName}}, err := nc.Get{{$node.PkgName}}{{$node.NodeName}}(context.TODO(), *id)
 		if err != nil {
 			log.Errorf("[getRootResolver]Error getting {{$node.NodeName}} node %q: %s", *id, err)
@@ -115,9 +115,9 @@ func getRootResolver(id *string) ([]*model.{{$node.PkgName}}{{$node.NodeName}}, 
 
 	v{{$node.NodeName}}ListObj, err := nc.{{$node.PkgName}}().List{{$node.GroupResourceNameTitle}}(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-        log.Errorf("[getRootResolver]Error getting {{$node.NodeName}} node %s", err)
-        return nil, nil
-    }
+		log.Errorf("[getRootResolver]Error getting {{$node.NodeName}} node %s", err)
+		return nil, nil
+	}
 	for _,i := range v{{$node.NodeName}}ListObj{
 		v{{$node.NodeName}}, err := nc.Get{{$node.PkgName}}{{$node.NodeName}}(context.TODO(), i.DisplayName())
 		if err != nil {

--- a/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
+++ b/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
@@ -65,6 +65,8 @@ func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
             return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 	    }
 	nc = nexusClient
+	nc.SubscribeAll()
+	log.Debugf("Subscribe api is called for all the nodes.")
 }
 
 	v{{$node.NodeName}}, err := nc.Get{{$node.PkgName}}{{$node.NodeName}}(context.TODO())

--- a/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
+++ b/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
@@ -58,16 +58,16 @@ func getK8sAPIEndpointConfig() *rest.Config {
 // PKG: {{$node.PkgName}}, NODE: {{$node.PkgName}}
 //////////////////////////////////////
 func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
-    if nc == nil {
-       k8sApiConfig := getK8sAPIEndpointConfig()
-	    nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-	    if err != nil {
-            return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-	    }
+	if nc == nil {
+		k8sApiConfig := getK8sAPIEndpointConfig()
+		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
+		}
 		nc = nexusClient
 		nc.SubscribeAll()
 		log.Debugf("Subscribed to all nodes in datamodel")
-    }
+	}
 
 	v{{$node.NodeName}}, err := nc.Get{{$node.PkgName}}{{$node.NodeName}}(context.TODO())
 	if err != nil {
@@ -85,23 +85,17 @@ func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
 // PKG: {{$node.PkgName}}, NODE: {{$node.PkgName}}
 //////////////////////////////////////
 func getRootResolver(id *string) ([]*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
-    if nc == nil {
-        k8sApiConfig := getK8sAPIEndpointConfig()
-	    nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-	    if err != nil {
-            return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-	    }
+	if nc == nil {
+		k8sApiConfig := getK8sAPIEndpointConfig()
+		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
+		}
 		nc = nexusClient
 		nc.SubscribeAll()
 		log.Debugf("Subscribed to all nodes in datamodel")
 	}
 
-	k8sApiConfig := getK8sAPIEndpointConfig()
-	nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-	}
-	nc = nexusClient
 	var v{{$node.NodeName}}List []*model.{{$node.PkgName}}{{$node.NodeName}}
 	if id != nil && *id != "" {
 	    log.Debugf("[getRootResolver]Id: %q", *id)

--- a/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
+++ b/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
@@ -64,10 +64,10 @@ func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
 	    if err != nil {
             return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 	    }
-	nc = nexusClient
-	nc.SubscribeAll()
-	log.Debugf("Subscribe api is called for all the nodes.")
-}
+		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribed to all nodes in datamodel")
+    }
 
 	v{{$node.NodeName}}, err := nc.Get{{$node.PkgName}}{{$node.NodeName}}(context.TODO())
 	if err != nil {
@@ -91,8 +91,11 @@ func getRootResolver(id *string) ([]*model.{{$node.PkgName}}{{$node.NodeName}}, 
 	    if err != nil {
             return nil, fmt.Errorf("failed to get k8s client config: %s", err)
 	    }
-	nc = nexusClient
-}
+		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribed to all nodes in datamodel")
+	}
+
 	k8sApiConfig := getK8sAPIEndpointConfig()
 	nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
 	if err != nil {

--- a/docs/getting_started/SubscribeAPI.md
+++ b/docs/getting_started/SubscribeAPI.md
@@ -70,9 +70,9 @@ func UseSubscribeAPIFeature(nexusClient *nexus_client.Clientset) {
 
     // check if a node is subscirbed
     if !nexusClient.OrgchartRoot().IsSubscribed(){
-        fmt.Prinln("Root is not subscribed.")
+        fmt.Println("Root is not subscribed.")
     }else{
-        fmt.Prinln("Root is subscribed.")
+        fmt.Println("Root is subscribed.")
     }
 
     // unsubscribe all nodes


### PR DESCRIPTION
Use subscribe API feature of nexus-client library in graphql to create cache of nexus nodes and to reduce load on api-server