### PR TITLE
Adding a check for docker in the install script.

### DIFF
--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -71,6 +71,8 @@ docker_name="nexus-cli"
 darwin_src_path="/nexus/darwin/nexus"
 linux_src_path="/nexus/linux/nexus"
 
+docker ps > /dev/null || echo "Unable to run docker command"
+
 docker rm -f ${docker_name} &> /dev/null
 
 docker pull ${REPOSITORY}:${VERSION} 1> /dev/null


### PR DESCRIPTION
If the docker command fails while installing, it's silent and the script does not print errors due to redirection of stderr to null on the first use of docker command.
This change will make sure to validate docker is accessible and print out the error on screen if it's not. 