### PR TITLE
NPT-768: Move script dependencies(tools like yq, tr) to docker image  

### DIFF
--- a/cli/Dockerfile.utils
+++ b/cli/Dockerfile.utils
@@ -1,0 +1,6 @@
+FROM gcr.io/nsx-sm/photon:4.0
+
+RUN tdnf install --refresh -y jq coreutils 
+ADD get-latest-version.sh /
+ENTRYPOINT ["/usr/bin/bash", "/get-latest-version.sh"]
+

--- a/cli/get-latest-version.sh
+++ b/cli/get-latest-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e 
+
+VERSION=""
+SEMVER_REGEX_MASTER="v[0-9]+\.[0-9]+\.[0-9]+$"
+
+json_resp=$(curl -s https://gcr.io/v2/nsx-sm/nexus/nexus-cli/tags/list | jq  -r '.manifest[] | .tag | select(.[]=="latest") | .[]')
+declare -a tags_array=($(echo "${json_resp}" | tr "\n" " "))
+for version in "${tags_array[@]}"; do
+       if [[ "${version}" =~ ${SEMVER_REGEX_MASTER} ]]; then
+                VERSION="${version}"
+                break
+       fi
+done
+
+echo "$VERSION" | tr -d '[:space:]'


### PR DESCRIPTION
Packaged docker image with a script to get the latest version of nexus, to avoid tools(example, yq/tr dependencies to the user