### PR TITLE
NPT-791: When nexus-rest-api-gen annotation var name is wrong, nexus compiler doesn't complain

### DIFF
--- a/compiler/example/test-utils/nexus-rest-api-gen-wrong-name/go.mod
+++ b/compiler/example/test-utils/nexus-rest-api-gen-wrong-name/go.mod
@@ -1,0 +1,5 @@
+module github.com/vmware-tanzu/graph-framework-for-microservices/compiler/example/test-utils/nexus-rest-api-gen-wrong-name
+
+go 1.18
+
+require github.com/vmware-tanzu/graph-framework-for-microservices/nexus v0.0.0-20230109084100-65931d1f8a32

--- a/compiler/example/test-utils/nexus-rest-api-gen-wrong-name/go.sum
+++ b/compiler/example/test-utils/nexus-rest-api-gen-wrong-name/go.sum
@@ -1,0 +1,2 @@
+github.com/vmware-tanzu/graph-framework-for-microservices/nexus v0.0.0-20230109084100-65931d1f8a32 h1:hOXi9xT6evW1um+yQVgGdg4Cx0YTaysl9Tnh+N3MkXs=
+github.com/vmware-tanzu/graph-framework-for-microservices/nexus v0.0.0-20230109084100-65931d1f8a32/go.mod h1:lDbjxzdIhK1mps93PuAyqX4LOWC6NhgoMaa4kzjZTgA=

--- a/compiler/example/test-utils/nexus-rest-api-gen-wrong-name/root.go
+++ b/compiler/example/test-utils/nexus-rest-api-gen-wrong-name/root.go
@@ -1,0 +1,22 @@
+package root
+
+import (
+	"github.com/vmware-tanzu/graph-framework-for-microservices/nexus/nexus"
+)
+
+var LeaderRestAPISpec = nexus.RestAPISpec{
+	Uris: []nexus.RestURIs{
+		{
+			Uri:     "/leader/{root.Leader}",
+			Methods: nexus.DefaultHTTPMethodsResponses,
+		},
+	},
+}
+
+// nexus-rest-api-gen:LeaderRestAPI
+type Leader struct {
+	nexus.Node
+
+	Name        string
+	Designation string
+}

--- a/compiler/pkg/parser/node_config.go
+++ b/compiler/pkg/parser/node_config.go
@@ -4,6 +4,8 @@ import (
 	"go/doc"
 	"regexp"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -18,7 +20,11 @@ func GetNexusSecretSpecAnnotation(pkg Package, name string) (string, bool) {
 }
 
 func GetNexusRestAPIGenAnnotation(pkg Package, name string) (string, bool) {
-	return getNexusAnnotation(pkg, name, NexusRestApiGenAnnotation)
+	anno, ok := getNexusAnnotation(pkg, name, NexusRestApiGenAnnotation)
+	if ok && !pkg.IsVarPresent(anno) {
+		log.Fatalf("Error: var %+s is not present", anno)
+	}
+	return anno, ok
 }
 
 func GetNexusDescriptionAnnotation(pkg Package, name string) (string, bool) {

--- a/compiler/pkg/parser/node_parser_test.go
+++ b/compiler/pkg/parser/node_parser_test.go
@@ -129,7 +129,8 @@ var _ = Describe("Node parser tests", func() {
 		graph := parser.ParseDSLNodes("../../example/test-utils/nexus-rest-api-gen-wrong-name", baseGroupName, pkgs, graphqlQueries)
 		parentsMap := parser.CreateParentsMap(graph)
 		methods, codes := rest.ParseResponses(pkgs)
-		generator.RenderCRDBaseTemplate(baseGroupName, pkg, parentsMap, methods, codes)
+		_, err := generator.RenderCRDBaseTemplate(baseGroupName, pkg, parentsMap, methods, codes)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(fail).To(BeTrue())
 	})
 

--- a/compiler/pkg/parser/pkg.go
+++ b/compiler/pkg/parser/pkg.go
@@ -178,6 +178,21 @@ func (p *Package) GetConsts() []*ast.ValueSpec {
 	return consts
 }
 
+func (p *Package) IsVarPresent(varName string) bool {
+	for _, genDecl := range p.GenDecls {
+		if genDecl.Tok == token.VAR {
+			for _, spec := range genDecl.Specs {
+				if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+					if varName == valueSpec.Names[0].Name {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 func IsNexusNode(n *ast.TypeSpec) bool {
 	if n == nil {
 		return false


### PR DESCRIPTION
[NPT-791] When nexus-rest-api-gen annotation var name is wrong, nexus compiler doesn't complain

This commit is to fail the compilation when nexus-rest-api-gen annotation var name is wrong.