### PR TITLE
NPT-799 fix for issue when the first query with root-Id gets panic

### DIFF
--- a/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/output/_rendered_templates/nexus-gql/graph/graphqlResolver.go
@@ -20,6 +20,20 @@ var c = GrpcClients{
 }
 var nc *nexus_client.Clientset
 
+func InitNexusClientSet() error {
+	if nc == nil {
+		k8sApiConfig := getK8sAPIEndpointConfig()
+		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
+		if err != nil {
+			return fmt.Errorf("failed to get k8s client config: %s", err)
+		}
+		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribed to all nodes in datamodel")
+	}
+	return nil
+}
+
 func getParentName(parentLabels map[string]interface{}, key string) string {
     if v, ok := parentLabels[key]; ok && v != nil {
 	    return v.(string)
@@ -56,14 +70,12 @@ func getK8sAPIEndpointConfig() *rest.Config {
 //////////////////////////////////////
 func getRootResolver() (*model.RootRoot, error) {
 	if nc == nil {
-		k8sApiConfig := getK8sAPIEndpointConfig()
-		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-		}
-		nc = nexusClient
-		nc.SubscribeAll()
-		log.Debugf("Subscribed to all nodes in datamodel")
+		log.Debugf("nc is nil in getRootResolver calling initNexusClientSet")
+        initNCErr := InitNexusClientSet()
+        if initNCErr != nil{
+            log.Errorf("[getRootResolver]Error initializing nexus client: %s", initNCErr)
+            return nil, nil
+        }
 	}
 
 	vRoot, err := nc.GetRootRoot(context.TODO())
@@ -71,6 +83,10 @@ func getRootResolver() (*model.RootRoot, error) {
 		log.Errorf("[getRootResolver]Error getting Root node %s", err)
 		return nil, nil
 	}
+	if vRoot == nil{
+        log.Errorf("[getRootResolver]Error getting Root node %s", err)
+        return nil, nil
+    }
 	dn := vRoot.DisplayName()
 parentLabels := map[string]interface{}{"roots.root.tsm.tanzu.vmware.com":dn}
 

--- a/compiler/example/output/_rendered_templates/nexus-gql/server.go
+++ b/compiler/example/output/_rendered_templates/nexus-gql/server.go
@@ -9,10 +9,15 @@ import (
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/handler"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/playground"
+	log "github.com/sirupsen/logrus"
 )
 
 
 func StartHttpServer() {
+    initNCErr := graph.InitNexusClientSet()
+    if initNCErr != nil{
+        log.Errorf("Error initializing nexus client in StartHttpServer: %s", initNCErr)
+    }
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowCredentials: true,

--- a/compiler/example/output/generated/nexus-gql/server.go
+++ b/compiler/example/output/generated/nexus-gql/server.go
@@ -7,11 +7,16 @@ import (
 	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/example/output/generated/nexus-gql/graph/generated"
 
 	"github.com/rs/cors"
+	log "github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/handler"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/playground"
 )
 
 func StartHttpServer() {
+	initNCErr := graph.InitNexusClientSet()
+	if initNCErr != nil {
+		log.Errorf("Error initializing nexus client in StartHttpServer: %s", initNCErr)
+	}
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowCredentials: true,

--- a/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
+++ b/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/graph/graphqlResolver.go
@@ -20,6 +20,20 @@ var c = GrpcClients{
 }
 var nc *nexus_client.Clientset
 
+func InitNexusClientSet() error {
+	if nc == nil {
+		k8sApiConfig := getK8sAPIEndpointConfig()
+		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
+		if err != nil {
+			return fmt.Errorf("failed to get k8s client config: %s", err)
+		}
+		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribed to all nodes in datamodel")
+	}
+	return nil
+}
+
 func getParentName(parentLabels map[string]interface{}, key string) string {
     if v, ok := parentLabels[key]; ok && v != nil {
 	    return v.(string)
@@ -56,14 +70,12 @@ func getK8sAPIEndpointConfig() *rest.Config {
 //////////////////////////////////////
 func getRootResolver() (*model.ConfigConfig, error) {
 	if nc == nil {
-		k8sApiConfig := getK8sAPIEndpointConfig()
-		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-		}
-		nc = nexusClient
-		nc.SubscribeAll()
-		log.Debugf("Subscribed to all nodes in datamodel")
+		log.Debugf("nc is nil in getRootResolver calling initNexusClientSet")
+        initNCErr := InitNexusClientSet()
+        if initNCErr != nil{
+            log.Errorf("[getRootResolver]Error initializing nexus client: %s", initNCErr)
+            return nil, nil
+        }
 	}
 
 	vConfig, err := nc.GetConfigConfig(context.TODO())
@@ -71,6 +83,10 @@ func getRootResolver() (*model.ConfigConfig, error) {
 		log.Errorf("[getRootResolver]Error getting Config node %s", err)
 		return nil, nil
 	}
+	if vConfig == nil{
+        log.Errorf("[getRootResolver]Error getting Root node %s", err)
+        return nil, nil
+    }
 	dn := vConfig.DisplayName()
 parentLabels := map[string]interface{}{"configs.config.tsm-tanzu.vmware.com":dn}
 vFieldX := string(vConfig.Spec.FieldX)

--- a/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/server.go
+++ b/compiler/example/test-utils/output-group-name-with-hyphen-datamodel/crd_generated/nexus-gql/server.go
@@ -9,10 +9,15 @@ import (
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/handler"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/playground"
+	log "github.com/sirupsen/logrus"
 )
 
 
 func StartHttpServer() {
+    initNCErr := graph.InitNexusClientSet()
+    if initNCErr != nil{
+        log.Errorf("Error initializing nexus client in StartHttpServer: %s", initNCErr)
+    }
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowCredentials: true,

--- a/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
+++ b/compiler/pkg/generator/template/graphql/graphqlResolver.go.tmpl
@@ -20,6 +20,20 @@ var c = GrpcClients{
 }
 var nc *nexus_client.Clientset
 
+func InitNexusClientSet() error {
+	if nc == nil {
+		k8sApiConfig := getK8sAPIEndpointConfig()
+		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
+		if err != nil {
+			return fmt.Errorf("failed to get k8s client config: %s", err)
+		}
+		nc = nexusClient
+		nc.SubscribeAll()
+		log.Debugf("Subscribed to all nodes in datamodel")
+	}
+	return nil
+}
+
 func getParentName(parentLabels map[string]interface{}, key string) string {
     if v, ok := parentLabels[key]; ok && v != nil {
 	    return v.(string)
@@ -59,14 +73,12 @@ func getK8sAPIEndpointConfig() *rest.Config {
 //////////////////////////////////////
 func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
 	if nc == nil {
-		k8sApiConfig := getK8sAPIEndpointConfig()
-		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-		}
-		nc = nexusClient
-		nc.SubscribeAll()
-		log.Debugf("Subscribed to all nodes in datamodel")
+		log.Debugf("nc is nil in getRootResolver calling initNexusClientSet")
+        initNCErr := InitNexusClientSet()
+        if initNCErr != nil{
+            log.Errorf("[getRootResolver]Error initializing nexus client: %s", initNCErr)
+            return nil, nil
+        }
 	}
 
 	v{{$node.NodeName}}, err := nc.Get{{$node.PkgName}}{{$node.NodeName}}(context.TODO())
@@ -74,6 +86,10 @@ func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
 		log.Errorf("[getRootResolver]Error getting {{$node.NodeName}} node %s", err)
 		return nil, nil
 	}
+	if v{{$node.NodeName}} == nil{
+        log.Errorf("[getRootResolver]Error getting Root node %s", err)
+        return nil, nil
+    }
 	{{ $node.Alias }}
 	{{ $node.ReturnType }}
 	log.Debugf("[getRootResolver]Output {{$node.NodeName}} object %+v", ret)
@@ -86,14 +102,12 @@ func getRootResolver() (*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
 //////////////////////////////////////
 func getRootResolver(id *string) ([]*model.{{$node.PkgName}}{{$node.NodeName}}, error) {
 	if nc == nil {
-		k8sApiConfig := getK8sAPIEndpointConfig()
-		nexusClient, err := nexus_client.NewForConfig(k8sApiConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get k8s client config: %s", err)
-		}
-		nc = nexusClient
-		nc.SubscribeAll()
-		log.Debugf("Subscribed to all nodes in datamodel")
+		log.Debugf("nc is nil in getRootResolver calling initNexusClientSet")
+        initNCErr := InitNexusClientSet()
+        if initNCErr != nil{
+            log.Errorf("[getRootResolver]Error initializing nexus client: %s", initNCErr)
+            return nil, nil
+        }
 	}
 
 	var v{{$node.NodeName}}List []*model.{{$node.PkgName}}{{$node.NodeName}}
@@ -104,6 +118,10 @@ func getRootResolver(id *string) ([]*model.{{$node.PkgName}}{{$node.NodeName}}, 
 			log.Errorf("[getRootResolver]Error getting {{$node.NodeName}} node %q: %s", *id, err)
 			return nil, nil
 		}
+		if v{{$node.NodeName}} == nil{
+            log.Errorf("[getRootResolver]Error getting Root node %s", err)
+            return nil, nil
+        }
 		{{ $node.Alias }}
 		{{ $node.ReturnType }}
 		v{{$node.NodeName}}List = append(v{{$node.NodeName}}List, ret)

--- a/compiler/pkg/generator/template/graphql/server.go.tmpl
+++ b/compiler/pkg/generator/template/graphql/server.go.tmpl
@@ -9,10 +9,15 @@ import (
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/handler"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/gqlgen/graphql/playground"
+	log "github.com/sirupsen/logrus"
 )
 
 
 func StartHttpServer() {
+    initNCErr := graph.InitNexusClientSet()
+    if initNCErr != nil{
+        log.Errorf("Error initializing nexus client in StartHttpServer: %s", initNCErr)
+    }
 	c := cors.New(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowCredentials: true,


### PR DESCRIPTION
The initialization of nexus client was being performed in the getRootResolver and this lead to cache miss when user invokes the query for the first time. The object returned is nil in this scenario and no check was performed before try to access object's variable thus causing the panic. The fix is to disconnect the initialization of nexus client logic from root resolver func and create separate init method to invoke it at the start of the server. Also added check for nil for root object being returned.
