### PR TITLE
COSMOS-1086: Add new type NexusGenericObject in nexus pkg

### DIFF
--- a/nexus/nexus/nexus.go
+++ b/nexus/nexus/nexus.go
@@ -19,6 +19,9 @@ type SingletonNode struct {
 	ID
 }
 
+// NexusGenericObject  type.
+type NexusGenericObject struct{}
+
 // HTTPMethod type.
 type HTTPMethod string
 


### PR DESCRIPTION
This commit is to add new type `NexusGenericObject` in nexus pkg
This new type is needed for cosmos DM