### PR TITLE
NPT-889: Fix issue in Delete{Node}ByName() method

### DIFF
--- a/compiler/pkg/generator/template/client.go.tmpl
+++ b/compiler/pkg/generator/template/client.go.tmpl
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"sync"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -172,7 +173,11 @@ func (group *{{$node.GroupTypeName}}) Delete{{$node.BaseNodeName}}ByName(ctx con
 		err := group.client.
 		{{$link.SimpleGroupTypeName}}().Delete{{$link.BaseNodeName}}ByName(ctx, v.Name)
 		if err != nil {
-			return err
+			if errors.IsNotFound(err) {
+				continue
+			}else{
+				return err
+			}
 		}
 	}
 	{{ else }}
@@ -180,7 +185,7 @@ func (group *{{$node.GroupTypeName}}) Delete{{$node.BaseNodeName}}ByName(ctx con
 		err := group.client.
 		{{$link.SimpleGroupTypeName}}().
 		Delete{{$link.BaseNodeName}}ByName(ctx, result.Spec.{{$link.FieldName}}Gvk.Name)
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
Fix issue in Delete{Node}ByName() method
Ignore Not Found error while deleting child/children of a node in DeleteNodeByName methods of nexus-client
