### PR TITLE
Npt 632 cosmos datamodel upgrade changes

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -155,7 +155,7 @@ preparser:
 	cp -R ${DATAMODEL_PATH} _tsm_temp
 	cp -R _generated_base_structure/* ${DATAMODEL_PATH}/build
 	@echo "Nexus Compiler: Running Preparser"
-	go run cmd/preparser/main.go -dsl _tsm_temp -output _generated -modpath ${PREPARSER_MODPATH}
+	go run cmd/preparser/main.go -config-file ${CONFIG_FILE} -dsl _tsm_temp -output _generated -modpath ${PREPARSER_MODPATH}
 	@echo "Nexus Compiler: Remove empty directories from model directory"
 	@find _generated/model -depth -type d -empty -delete
 

--- a/compiler/cmd/preparser/main.go
+++ b/compiler/cmd/preparser/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"flag"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/config"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/preparser"
 )
 
 func main() {
+	configFile := flag.String("config-file", "", "Config file location.")
 	dslDir := flag.String("dsl", "datamodel", "DSL file location.")
 	outputDir := flag.String("output", "_generated", "output dir location.")
 	modPath := flag.String("modpath", "datamodel", "ModPath for rendered imports")
@@ -20,6 +22,14 @@ func main() {
 	}
 	log.SetLevel(lvl)
 
+	conf := &config.Config{}
+	if *configFile != "" {
+		conf, err = config.LoadConfig(*configFile)
+		if err != nil {
+			log.Fatalf("Error loading config: %v", err)
+		}
+	}
+	config.ConfigInstance = conf
 	packages := preparser.Parse(*dslDir)
 	err = preparser.Render(*dslDir, packages)
 	if err != nil {

--- a/compiler/pkg/parser/node_parser.go
+++ b/compiler/pkg/parser/node_parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/config"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -40,6 +41,12 @@ func ParseDSLNodes(startPath string, baseGroupName string, packages Packages,
 			if info.Name() == "vendor" {
 				log.Infof("Ignoring vendor directory...")
 				return filepath.SkipDir
+			}
+			for _, f := range config.ConfigInstance.IgnoredDirs {
+				if info.Name() == f {
+					log.Infof(fmt.Sprintf("Ignoring %v directory from config", f))
+					return filepath.SkipDir
+				}
 			}
 			pkgs, err := parser.ParseDir(fileset, path, nil, parser.ParseComments)
 			if err != nil {

--- a/compiler/pkg/preparser/preparser.go
+++ b/compiler/pkg/preparser/preparser.go
@@ -3,6 +3,7 @@ package preparser
 import (
 	"bytes"
 	"fmt"
+	"github.com/vmware-tanzu/graph-framework-for-microservices/compiler/pkg/config"
 	"go/ast"
 	goParser "go/parser"
 	"go/printer"
@@ -35,7 +36,12 @@ func Parse(startPath string) map[string][]*parser.Package {
 				log.Infof("Ignoring vendor directory...")
 				return filepath.SkipDir
 			}
-
+			for _, f := range config.ConfigInstance.IgnoredDirs {
+				if info.Name() == f {
+					log.Infof(fmt.Sprintf("Ignoring %v directory from config", f))
+					return filepath.SkipDir
+				}
+			}
 			fileset := token.NewFileSet()
 			pkgs, err := goParser.ParseDir(fileset, path, nil, goParser.ParseComments)
 			if err != nil {


### PR DESCRIPTION
Updated the compiler to support the cosmos datamodel upgrdade

The preparser and node_parser were not skipping the ignoredDirs configured in config file(nexus.yaml)

Initialized the config object in cmd/preparser/main.go and added code to skip parsing of ignoredDirs in preparser.go and node_parser.go