### PR TITLE
[COSMOS-2218] Nexus Install script log improvements

### DIFF
--- a/cli/get-nexus-cli.sh
+++ b/cli/get-nexus-cli.sh
@@ -16,6 +16,11 @@ for version in "${tags_array[@]}"; do
        fi
 done
 
+if [[ -z "${VERSION}" ]]; then
+   echo "Unable to get the nexus image tag, Please contact Nexus Support"
+   exit 1
+fi
+
 usage() { echo "Usage: $0 [-r <repository-name>] [-v <version>] [-d <install-directory>] " 1>&2; exit 1; }
 
 if [[ $# == 0 ]]; then
@@ -75,6 +80,7 @@ docker ps > /dev/null || echo "Unable to run docker command"
 
 docker rm -f ${docker_name} &> /dev/null
 
+echo "Installing Nexus..."
 docker pull ${REPOSITORY}:${VERSION} 1> /dev/null
 docker create --name "$docker_name" ${REPOSITORY}:${VERSION} 1> /dev/null
 


### PR DESCRIPTION
Check added for valid tag version and log message added while Installing Nexus.

Example output:

For  'invalid reference format

  The log will be as below:
     bash cli/get-nexus-cli.sh --no-prompt
     Unable to get the nexus image tag, Please contact Nexus Support


Valid case:
❯ bash cli/get-nexus-cli.sh --no-prompt
Downloading Nexus ...
Version: v0.0.162
Image repository: gcr.io/nsx-sm/nexus/nexus-cli
Directory: /usr/local/bin

Installing Nexus...
Nexus (v0.0.162) installed in /usr/local/bin/nexus
Run "nexus help" to get started