### PR TITLE
COSMOS-2804: Nexus SDK should be able to infer the annotations and labels needs it and not need the app code to populate them

### DIFF
--- a/compiler/pkg/generator/template/client.go.tmpl
+++ b/compiler/pkg/generator/template/client.go.tmpl
@@ -40,6 +40,7 @@ fakeBaseClienset {{.FakeBaseCliensetImport}}
 var log = logrus.New()
 const maxRetryCount = 12
 const sleepTime = 5
+const ownershipAnnotation string = "Ownership"
 
 type Clientset struct {
 	baseClient baseClientset.Interface
@@ -633,45 +634,40 @@ func (group *{{$node.GroupTypeName}}) Update{{$node.BaseNodeName}}ByName(ctx con
 	{{if $node.IsSingleton }}if objToUpdate.Labels[common.DISPLAY_NAME_LABEL] != helper.DEFAULT_KEY {
 		return nil, NewSingletonNameError(objToUpdate.Labels[common.DISPLAY_NAME_LABEL])
 	}{{end}}
-	// ResourceVersion must be set for update
-	retryCount := 0
-	if objToUpdate.ResourceVersion == "" {
-		for {
-			current, err := group.client.baseClient.
-			{{$node.GroupTypeName}}().
-			{{$node.GroupResourceNameTitle}}().Get(ctx, objToUpdate.GetName(), metav1.GetOptions{})
-			if err != nil {
-				log.Errorf("[Update{{$node.BaseNodeName}}ByName] Failed to Get {{$node.GroupResourceNameTitle}}: %+v",err)
-				if errors.IsTimeout(err) || customerrors.Is(err, context.DeadlineExceeded){
-					log.Errorf("[Retry Count: %d ] %+v",retryCount,err)
-					if retryCount == maxRetryCount {
-						log.Error("Max Retry exceed on Get {{$node.GroupResourceNameTitle}}")
-						return nil,err
-					}
-					retryCount +=1
-					time.Sleep(sleepTime * time.Second)
-				} else if customerrors.Is(err, context.Canceled){
-					log.Errorf("[Update{{$node.BaseNodeName}}ByName]: %+v",err)
-					return nil,context.Canceled
-				}else {
-					log.Errorf("[Update{{$node.BaseNodeName}}ByName]: %+v",err)
-					return nil,err
-				}
-			} else {
-				log.Debugf("[Update{{$node.BaseNodeName}}ByName] Successfully Get: %s",objToUpdate.GetName())
-				objToUpdate.ResourceVersion = current.ResourceVersion
-				break
-			}
-		}
-	}
 
 	var patch Patch
-	patch = append(patch, PatchOp{
-		Op:    "replace",
-		Path:  "/metadata",
-		Value: objToUpdate.ObjectMeta,
-	})
 
+	if objToUpdate.Annotations != nil || objToUpdate.Labels != nil {
+		current , err := group.client.{{$node.SimpleGroupTypeName}}().Get{{$node.BaseNodeName}}ByName(ctx, objToUpdate.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		if objToUpdate.Annotations !=nil {
+			if current.Annotations[ownershipAnnotation] != ""{
+				objToUpdate.Annotations[ownershipAnnotation] = current.Annotations[ownershipAnnotation]
+			}
+			patch = append(patch, PatchOp{
+				Op:    "replace",
+				Path:  "/metadata/annotations",
+				Value: objToUpdate.Annotations,
+			})
+		}
+
+		if  objToUpdate.Labels !=nil {
+			parentsList := helper.GetCRDParentsMap()["{{$node.CrdName}}"]
+			for _,k := range parentsList{
+				objToUpdate.Labels[k] = current.Labels[k]
+			}
+			objToUpdate.Labels[common.IS_NAME_HASHED_LABEL] = current.Labels[common.IS_NAME_HASHED_LABEL]
+			objToUpdate.Labels[common.DISPLAY_NAME_LABEL] = current.Labels[common.DISPLAY_NAME_LABEL]
+			patch = append(patch, PatchOp{
+				Op:    "replace",
+				Path:  "/metadata/labels",
+				Value: objToUpdate.Labels,
+			})
+		}
+	}
 
 	{{ if gt (len .Fields) 0}}
 	var rt reflect.Type
@@ -707,6 +703,7 @@ func (group *{{$node.GroupTypeName}}) Update{{$node.BaseNodeName}}ByName(ctx con
 		result *{{$node.GroupBaseImport}}
 	)
 	newCtx := context.TODO()
+	retryCount := 0
 	for {
 		result, err = group.client.baseClient.
 		{{$node.GroupTypeName}}().


### PR DESCRIPTION
In Nexus SDK, the update method expect that the object metadata (along with the annotations and labels) be populated on the object before an update is called.

Nexus SDK should be able to infer the annotations and labels needs it and not need the app code to populate them for every update.
