### PR TITLE
COSMOS-3251: Crd field generated in uppercase for field with nexus.NexusGenericObject type

### DIFF
--- a/compiler/example/output/_rendered_templates/apis/config.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/_rendered_templates/apis/config.tsm.tanzu.vmware.com/v1/types.go
@@ -77,7 +77,7 @@ type ConfigSpec struct {
 	ClusterNamespaces []ClusterNamespace                      `json:"clusterNamespaces" yaml:"clusterNamespaces"`
 	TestValMarkers    TestValMarkers                          `json:"testValMarkers" yaml:"testValMarkers"`
 	Instance          float32                                 `json:"instance" yaml:"instance"`
-	CuOption          string                                  `json:"option_cu"`
+	CuOption          string                                  `json:"option_cu" yaml:"option_cu"`
 	GNSGvk            *Child                                  `json:"gNSGvk,omitempty" yaml:"gNSGvk,omitempty" nexus:"child"`
 	DNSGvk            *Child                                  `json:"dNSGvk,omitempty" yaml:"dNSGvk,omitempty" nexus:"child"`
 	VMPPoliciesGvk    *Child                                  `json:"vMPPoliciesGvk,omitempty" yaml:"vMPPoliciesGvk,omitempty" nexus:"child"`
@@ -126,9 +126,9 @@ func (c *FooTypeABC) DisplayName() string {
 type FooTypeABCSpec struct {
 	FooA AMap   `json:"fooA" yaml:"fooA"`
 	FooB BArray `json:"fooB" yaml:"fooB"`
-	FooC CInt   `nexus-graphql:"ignore:true"`
-	FooD DFloat `nexus-graphql:"type:string"`
-	FooE CInt   `json:"foo_e" nexus-graphql:"ignore:true"`
+	FooC CInt   `nexus-graphql:"ignore:true" json:"fooC" yaml:"fooC"`
+	FooD DFloat `nexus-graphql:"type:string" json:"fooD" yaml:"fooD"`
+	FooE CInt   `json:"foo_e" nexus-graphql:"ignore:true" yaml:"foo_e"`
 	FooF DFloat `json:"foo_f" yaml:"c_int" nexus-graphql:"type:string"`
 }
 

--- a/compiler/example/output/_rendered_templates/apis/gns.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/_rendered_templates/apis/gns.tsm.tanzu.vmware.com/v1/types.go
@@ -115,21 +115,21 @@ type GnsSpec struct {
 	//nexus-validation: Pattern=abc
 	Domain                    string                       `json:"domain" yaml:"domain"`
 	UseSharedGateway          bool                         `json:"useSharedGateway" yaml:"useSharedGateway"`
-	Annotations               nexus.NexusGenericObject     `nexus-graphql-jsonencoded:""`
-	TargetPort                intstr.IntOrString           `json:"targetPort,omitempty" mapstructure:"targetPort,omitempty"`
+	Annotations               nexus.NexusGenericObject     `nexus-graphql-jsonencoded:"" json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	TargetPort                intstr.IntOrString           `json:"targetPort,omitempty" mapstructure:"targetPort,omitempty" yaml:"targetPort,omitempty"`
 	Description               Description                  `json:"description" yaml:"description"`
 	Meta                      string                       `json:"meta" yaml:"meta"`
-	IntOrString               []intstr.IntOrString         `nexus-graphql-type-name:"IntOrString" json:"intOrString,omitempty" mapstructure:"intOrString,omitempty"`
+	IntOrString               []intstr.IntOrString         `nexus-graphql-type-name:"IntOrString" json:"intOrString,omitempty" mapstructure:"intOrString,omitempty" yaml:"intOrString,omitempty"`
 	Port                      *int                         `json:"port" yaml:"port"`
 	OtherDescription          *Description                 `json:"otherDescription" yaml:"otherDescription"`
 	MapPointer                *map[string]string           `json:"mapPointer" yaml:"mapPointer"`
 	SlicePointer              *[]string                    `json:"slicePointer" yaml:"slicePointer"`
 	WorkloadSpec              cartv1.WorkloadSpec          `json:"workloadSpec" yaml:"workloadSpec"`
 	DifferentSpec             *cartv1.WorkloadSpec         `json:"differentSpec" yaml:"differentSpec"`
-	ServiceSegmentRef         ServiceSegmentRef            `json:"serviceSegmentRef,omitempty"`
-	ServiceSegmentRefPointer  *ServiceSegmentRef           `json:"serviceSegmentRefPointer,omitempty"`
-	ServiceSegmentRefs        []ServiceSegmentRef          `json:"serviceSegmentRefs,omitempty"`
-	ServiceSegmentRefMap      map[string]ServiceSegmentRef `json:"serviceSegmentRefMap,omitempty"`
+	ServiceSegmentRef         ServiceSegmentRef            `json:"serviceSegmentRef,omitempty" yaml:"serviceSegmentRef,omitempty"`
+	ServiceSegmentRefPointer  *ServiceSegmentRef           `json:"serviceSegmentRefPointer,omitempty" yaml:"serviceSegmentRefPointer,omitempty"`
+	ServiceSegmentRefs        []ServiceSegmentRef          `json:"serviceSegmentRefs,omitempty" yaml:"serviceSegmentRefs,omitempty"`
+	ServiceSegmentRefMap      map[string]ServiceSegmentRef `json:"serviceSegmentRefMap,omitempty" yaml:"serviceSegmentRefMap,omitempty"`
 	GnsServiceGroupsGvk       map[string]Child             `json:"gnsServiceGroupsGvk,omitempty" yaml:"gnsServiceGroupsGvk,omitempty" nexus:"children"`
 	GnsAccessControlPolicyGvk *Child                       `json:"gnsAccessControlPolicyGvk,omitempty" yaml:"gnsAccessControlPolicyGvk,omitempty" nexus:"child"`
 	FooChildGvk               *Child                       `json:"fooChildGvk,omitempty" yaml:"fooChildGvk,omitempty" nexus:"child"`

--- a/compiler/example/output/generated/apis/config.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/generated/apis/config.tsm.tanzu.vmware.com/v1/types.go
@@ -77,7 +77,7 @@ type ConfigSpec struct {
 	ClusterNamespaces []ClusterNamespace                      `json:"clusterNamespaces" yaml:"clusterNamespaces"`
 	TestValMarkers    TestValMarkers                          `json:"testValMarkers" yaml:"testValMarkers"`
 	Instance          float32                                 `json:"instance" yaml:"instance"`
-	CuOption          string                                  `json:"option_cu"`
+	CuOption          string                                  `json:"option_cu" yaml:"option_cu"`
 	GNSGvk            *Child                                  `json:"gNSGvk,omitempty" yaml:"gNSGvk,omitempty" nexus:"child"`
 	DNSGvk            *Child                                  `json:"dNSGvk,omitempty" yaml:"dNSGvk,omitempty" nexus:"child"`
 	VMPPoliciesGvk    *Child                                  `json:"vMPPoliciesGvk,omitempty" yaml:"vMPPoliciesGvk,omitempty" nexus:"child"`
@@ -126,9 +126,9 @@ func (c *FooTypeABC) DisplayName() string {
 type FooTypeABCSpec struct {
 	FooA AMap   `json:"fooA" yaml:"fooA"`
 	FooB BArray `json:"fooB" yaml:"fooB"`
-	FooC CInt   `nexus-graphql:"ignore:true"`
-	FooD DFloat `nexus-graphql:"type:string"`
-	FooE CInt   `json:"foo_e" nexus-graphql:"ignore:true"`
+	FooC CInt   `nexus-graphql:"ignore:true" json:"fooC" yaml:"fooC"`
+	FooD DFloat `nexus-graphql:"type:string" json:"fooD" yaml:"fooD"`
+	FooE CInt   `json:"foo_e" nexus-graphql:"ignore:true" yaml:"foo_e"`
 	FooF DFloat `json:"foo_f" yaml:"c_int" nexus-graphql:"type:string"`
 }
 

--- a/compiler/example/output/generated/apis/gns.tsm.tanzu.vmware.com/v1/types.go
+++ b/compiler/example/output/generated/apis/gns.tsm.tanzu.vmware.com/v1/types.go
@@ -115,21 +115,21 @@ type GnsSpec struct {
 	//nexus-validation: Pattern=abc
 	Domain                    string                       `json:"domain" yaml:"domain"`
 	UseSharedGateway          bool                         `json:"useSharedGateway" yaml:"useSharedGateway"`
-	Annotations               nexus.NexusGenericObject     `nexus-graphql-jsonencoded:""`
-	TargetPort                intstr.IntOrString           `json:"targetPort,omitempty" mapstructure:"targetPort,omitempty"`
+	Annotations               nexus.NexusGenericObject     `nexus-graphql-jsonencoded:"" json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	TargetPort                intstr.IntOrString           `json:"targetPort,omitempty" mapstructure:"targetPort,omitempty" yaml:"targetPort,omitempty"`
 	Description               Description                  `json:"description" yaml:"description"`
 	Meta                      string                       `json:"meta" yaml:"meta"`
-	IntOrString               []intstr.IntOrString         `nexus-graphql-type-name:"IntOrString" json:"intOrString,omitempty" mapstructure:"intOrString,omitempty"`
+	IntOrString               []intstr.IntOrString         `nexus-graphql-type-name:"IntOrString" json:"intOrString,omitempty" mapstructure:"intOrString,omitempty" yaml:"intOrString,omitempty"`
 	Port                      *int                         `json:"port" yaml:"port"`
 	OtherDescription          *Description                 `json:"otherDescription" yaml:"otherDescription"`
 	MapPointer                *map[string]string           `json:"mapPointer" yaml:"mapPointer"`
 	SlicePointer              *[]string                    `json:"slicePointer" yaml:"slicePointer"`
 	WorkloadSpec              cartv1.WorkloadSpec          `json:"workloadSpec" yaml:"workloadSpec"`
 	DifferentSpec             *cartv1.WorkloadSpec         `json:"differentSpec" yaml:"differentSpec"`
-	ServiceSegmentRef         ServiceSegmentRef            `json:"serviceSegmentRef,omitempty"`
-	ServiceSegmentRefPointer  *ServiceSegmentRef           `json:"serviceSegmentRefPointer,omitempty"`
-	ServiceSegmentRefs        []ServiceSegmentRef          `json:"serviceSegmentRefs,omitempty"`
-	ServiceSegmentRefMap      map[string]ServiceSegmentRef `json:"serviceSegmentRefMap,omitempty"`
+	ServiceSegmentRef         ServiceSegmentRef            `json:"serviceSegmentRef,omitempty" yaml:"serviceSegmentRef,omitempty"`
+	ServiceSegmentRefPointer  *ServiceSegmentRef           `json:"serviceSegmentRefPointer,omitempty" yaml:"serviceSegmentRefPointer,omitempty"`
+	ServiceSegmentRefs        []ServiceSegmentRef          `json:"serviceSegmentRefs,omitempty" yaml:"serviceSegmentRefs,omitempty"`
+	ServiceSegmentRefMap      map[string]ServiceSegmentRef `json:"serviceSegmentRefMap,omitempty" yaml:"serviceSegmentRefMap,omitempty"`
 	GnsServiceGroupsGvk       map[string]Child             `json:"gnsServiceGroupsGvk,omitempty" yaml:"gnsServiceGroupsGvk,omitempty" nexus:"children"`
 	GnsAccessControlPolicyGvk *Child                       `json:"gnsAccessControlPolicyGvk,omitempty" yaml:"gnsAccessControlPolicyGvk,omitempty" nexus:"child"`
 	FooChildGvk               *Child                       `json:"fooChildGvk,omitempty" yaml:"fooChildGvk,omitempty" nexus:"child"`

--- a/compiler/example/output/generated/crds/config_footypeabc.yaml
+++ b/compiler/example/output/generated/crds/config_footypeabc.yaml
@@ -38,12 +38,6 @@ spec:
             type: object
           spec:
             properties:
-              FooC:
-                format: byte
-                type: integer
-              FooD:
-                format: float
-                type: number
               foo_e:
                 format: byte
                 type: integer
@@ -58,11 +52,17 @@ spec:
                 items:
                   type: string
                 type: array
+              fooC:
+                format: byte
+                type: integer
+              fooD:
+                format: float
+                type: number
             required:
             - fooA
             - fooB
-            - FooC
-            - FooD
+            - fooC
+            - fooD
             - foo_e
             - foo_f
             type: object

--- a/compiler/example/output/generated/crds/gns_gns.yaml
+++ b/compiler/example/output/generated/crds/gns_gns.yaml
@@ -38,7 +38,7 @@ spec:
             type: object
           spec:
             properties:
-              Annotations:
+              annotations:
                 x-kubernetes-preserve-unknown-fields: true
               description:
                 properties:
@@ -283,7 +283,6 @@ spec:
             required:
             - domain
             - useSharedGateway
-            - Annotations
             - description
             - meta
             - port
@@ -292,6 +291,7 @@ spec:
             - slicePointer
             - workloadSpec
             - differentSpec
+            - annotations
             type: object
           status:
             properties:

--- a/compiler/example/output/generated/crds/gns_gns.yaml
+++ b/compiler/example/output/generated/crds/gns_gns.yaml
@@ -291,7 +291,6 @@ spec:
             - slicePointer
             - workloadSpec
             - differentSpec
-            - annotations
             type: object
           status:
             properties:

--- a/compiler/pkg/openapi_generator/generator.go
+++ b/compiler/pkg/openapi_generator/generator.go
@@ -183,22 +183,6 @@ func (g *Generator) resolveRefsForPackage(pkg string) error {
 
 	fmt.Printf("Resolving refs for %v\n", pkg)
 
-	for property, propSchema := range pkgSchema.schema.Properties {
-		if propSchema.Ref != nil &&
-			*propSchema.Ref == "github.com/vmware-tanzu/graph-framework-for-microservices/nexus/nexus.nexusgenericobject" {
-			newName := convertToCamelCase(strings.ToLower(property[:1]) + property[1:])
-			pkgSchema.schema.Properties[newName] = propSchema
-			delete(pkgSchema.schema.Properties, property)
-
-			for i, v := range pkgSchema.schema.Required {
-				if v == property {
-					pkgSchema.schema.Required = append(pkgSchema.schema.Required, newName)
-					pkgSchema.schema.Required = append(pkgSchema.schema.Required[:i], pkgSchema.schema.Required[i+1:]...)
-				}
-			}
-		}
-	}
-
 	g.resolveRefsInProperty(pkgSchema.schema)
 	g.resolveRefsInProperties(pkgSchema.schema)
 	g.resolveRefsInAdditionalProperties(pkgSchema.schema)
@@ -447,15 +431,15 @@ func (g *Generator) createName(group, apiVersion, name string) string {
 	return strings.ToLower(fmt.Sprintf("%s/%s/%s.%s", g.namePrefix, group, apiVersion, name))
 }
 
-func convertToCamelCase(input string) string {
-	if !strings.Contains(input, "_") {
-		return input
-	}
-	parts := strings.Split(input, "_")
-	camelCaseName := parts[0]
-	for _, p := range parts[1:] {
-		camelCaseName += strings.ToUpper(string(p[0]))
-		camelCaseName += p[1:]
-	}
-	return camelCaseName
-}
+//func convertToCamelCase(input string) string {
+//	if !strings.Contains(input, "_") {
+//		return input
+//	}
+//	parts := strings.Split(input, "_")
+//	camelCaseName := parts[0]
+//	for _, p := range parts[1:] {
+//		camelCaseName += strings.ToUpper(string(p[0]))
+//		camelCaseName += p[1:]
+//	}
+//	return camelCaseName
+//}


### PR DESCRIPTION
CRD fields with graphql annotations were generated without json and yaml tags.

Changed the logic of building tag for fields. Now it will add json and yaml tags if they are missing.